### PR TITLE
On IMAP4 abort, include any prior ALERT message

### DIFF
--- a/imapclient/test/test_imapclient.py
+++ b/imapclient/test/test_imapclient.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 
 import itertools
+import imaplib
 import socket
 import sys
 from datetime import datetime
@@ -569,6 +570,15 @@ class TestRawCommand(IMAPClientTest):
         with self.assertRaisesRegex(IMAPClient.AbortError, expected_error):
             self.client._raw_command(b'FOO', [b'\xff'])
 
+    def test_alert_included_in_abort(self):
+        mock = Mock()
+        mock.side_effect = imaplib.IMAP4.abort("socket error")
+        self.client._imap.create = mock
+        self.client._imap.untagged_responses = {'ALERT': [b'You will be disconnected.']}
+
+        expected_error = "socket error. Alert: \['You will be disconnected.'\]"
+        with self.assertRaisesRegex(IMAPClient.AbortError, expected_error):
+            self.client.create_folder('test')
 
 class TestShutdown(IMAPClientTest):
 


### PR DESCRIPTION
We're seeing a large number of socket disconnections for a small subset of accounts on the sync engine while we're trying to perform "syncback" of changes. I think that we're probably receiving an unsolicited ALERT message from the server before the socket is closed. The goal of this patch is to capture that ALERT message so that we can see if there's more information we could use to debug the issue. (Hopefully this is a "too many commands too quickly", "this account has been suspended", etc., sort of response.)

It'd also be interesting to implement more generic support for ALERT messages—what do you think?
