### PR TITLE
Tests for bad data in folder_status, more robust handling

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -635,10 +635,11 @@ class IMAPClient(object):
             what = normalise_text_list(what)
         what_ = '(%s)' % (' '.join(what))
 
-        data = self._command_and_check('status', self._normalise_folder(folder), what_)
+        fname = self._normalise_folder(folder)
+        data = self._command_and_check('status', fname, what_)
         response = parse_response(data)
         try:
-            _, status_items = response
+            status_items = response[-1]
         except ValueError:
             raise Exception('folder_status ValueError: Input ' + str(response))
         return dict(as_pairs(status_items))


### PR DESCRIPTION
In the last day we’ve seen this ValueError 249,915 times. It looks like the response can be more than two parts if A) the mailbox name contains spaces or B) the server decides to send us other data (or IMAPClient rolls it into the response buffer, not clear yet.) Either way, we should be able to handle these scenarios without crashing.


Relevant internal logs: https://nylas.loggly.com/search#terms=%22folder_status%20ValueError%22&from=2016-09-02T01%3A57%3A05.585Z&until=2016-09-03T01%3A57%3A05.585Z&source_group=