### PR TITLE
Python 3.4 adjustments

### DIFF
--- a/imapclient/__init__.py
+++ b/imapclient/__init__.py
@@ -7,10 +7,17 @@
 
 from __future__ import unicode_literals
 
+from .version import author as __author__, version as __version__, version_info
 from .imapclient import *
 from .response_parser import *
-from .tls import *
-from .version import author as __author__, version as __version__, version_info
-
-from .imaplib_ssl_fix import apply_patch
-apply_patch()
+# if backports.ssl is importable use it with our own ssl wrapper
+# otherwise use the ssl module, that was shipped with python{2,3}
+try:
+    import backports.ssl
+except ImportError:
+    import ssl as tls
+else:
+    del backports.ssl
+    from . import tls
+    from .imaplib_ssl_fix import apply_patch
+    apply_patch()

--- a/imapclient/config.py
+++ b/imapclient/config.py
@@ -11,7 +11,10 @@ except ImportError:
     from configparser import SafeConfigParser, NoOptionError
 
 from os import path
-from backports import ssl
+try:
+    from backports import ssl
+except ImportError:
+    import ssl
 
 from six import iteritems
 from six.moves.urllib.request import urlopen

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -23,7 +23,15 @@ except ImportError:
 
 from . import imap4
 from . import response_lexer
-from . import tls
+# if backports.ssl is importable use it with our own ssl wrapper
+# otherwise use the ssl module, that was shipped with python{2,3}
+try:
+    import backports.ssl
+except ImportError:
+    import ssl as tls
+else:
+    del backports.ssl
+    from . import tls
 from .datetime_util import datetime_to_INTERNALDATE, format_criteria_date
 from .imap_utf7 import encode as encode_utf7, decode as decode_utf7
 from .response_parser import parse_response, parse_message_list, parse_fetch_response

--- a/imapclient/test/test_datetime_util.py
+++ b/imapclient/test/test_datetime_util.py
@@ -6,7 +6,10 @@ from __future__ import unicode_literals
 
 from datetime import datetime, date
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from ..datetime_util import (
     datetime_to_INTERNALDATE,

--- a/imapclient/test/test_fixed_offset.py
+++ b/imapclient/test/test_fixed_offset.py
@@ -5,7 +5,10 @@
 from __future__ import unicode_literals
 
 from datetime import timedelta
-from mock import Mock, patch, DEFAULT
+try:
+    from unittest.mock import Mock, patch, DEFAULT
+except ImportError:
+    from mock import Mock, patch, DEFAULT
 from imapclient.test.util import unittest
 from imapclient.fixed_offset import FixedOffset
 

--- a/imapclient/test/test_folder_status.py
+++ b/imapclient/test/test_folder_status.py
@@ -4,7 +4,10 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from .imapclient_test import IMAPClientTest
 
@@ -45,18 +48,18 @@ class TestFolderStatus(IMAPClientTest):
     def test_extra_response(self):
         # In production, we've seen folder names containing spaces come back
         # like this and be broken into two components in the tuple.
-        server_response = ["My files (UIDNEXT 24369)"]
+        server_response = [b"My files (UIDNEXT 24369)"]
         mock = Mock(return_value=server_response)
         self.client._command_and_check = mock
 
-        resp = self.client.folder_status('My files', ['UIDNEXT'])
-        self.assertEqual(resp, {'UIDNEXT': 24369})
+        resp = self.client.folder_status(b'My files', ['UIDNEXT'])
+        self.assertEqual(resp, {b'UIDNEXT': 24369})
 
         # We've also seen the response contain mailboxes we didn't
         # ask for. In all known cases, the desired mailbox is last.
-        server_response = ["sent (UIDNEXT 123)\nINBOX (UIDNEXT 24369)"]
+        server_response = [b"sent (UIDNEXT 123)\nINBOX (UIDNEXT 24369)"]
         mock = Mock(return_value=server_response)
         self.client._command_and_check = mock
 
-        resp = self.client.folder_status('INBOX', ['UIDNEXT'])
-        self.assertEqual(resp, {'UIDNEXT': 24369})
+        resp = self.client.folder_status(b'INBOX', ['UIDNEXT'])
+        self.assertEqual(resp, {b'UIDNEXT': 24369})

--- a/imapclient/test/test_imapclient.py
+++ b/imapclient/test/test_imapclient.py
@@ -10,7 +10,10 @@ import sys
 from datetime import datetime
 
 import six
-from mock import patch, sentinel, Mock
+try:
+    from unittest.mock import patch, sentinel, Mock
+except ImportError:
+    from mock import patch, sentinel, Mock
 
 from imapclient.fixed_offset import FixedOffset
 from .testable_imapclient import TestableIMAPClient as IMAPClient

--- a/imapclient/test/test_init.py
+++ b/imapclient/test/test_init.py
@@ -2,7 +2,10 @@
 # Released subject to the New BSD License
 # Please see http://en.wikipedia.org/wiki/BSD_licenses
 
-from mock import patch, sentinel, Mock
+try:
+    from unittest.mock import patch, sentinel, Mock
+except ImportError:
+    from mock import patch, sentinel, Mock
 
 from imapclient.imapclient import IMAPClient
 from imapclient.test.util import unittest

--- a/imapclient/test/test_search.py
+++ b/imapclient/test/test_search.py
@@ -6,7 +6,10 @@ from __future__ import unicode_literals
 
 from datetime import date, datetime
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from .imapclient_test import IMAPClientTest
 

--- a/imapclient/test/test_sort.py
+++ b/imapclient/test/test_sort.py
@@ -4,7 +4,10 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from .imapclient_test import IMAPClientTest
 

--- a/imapclient/test/test_starttls.py
+++ b/imapclient/test/test_starttls.py
@@ -4,7 +4,10 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock, patch, sentinel
+try:
+    from unittest.mock import Mock, patch, sentinel
+except ImportError:
+    from mock import Mock, patch, sentinel
 
 from ..imapclient import IMAPClient
 from .imapclient_test import IMAPClientTest

--- a/imapclient/test/test_store.py
+++ b/imapclient/test/test_store.py
@@ -5,7 +5,10 @@
 from __future__ import unicode_literals
 
 import six
-from mock import patch, sentinel, Mock
+try:
+    from unittest.mock import patch, sentinel, Mock
+except ImportError:
+    from mock import patch, sentinel, Mock
 
 from imapclient import DELETED, SEEN, ANSWERED, FLAGGED, DRAFT, RECENT
 from .imapclient_test import IMAPClientTest
@@ -30,7 +33,7 @@ class TestFlags(IMAPClientTest):
                           return_value={123: {b'FLAGS': [b'foo', b'bar']},
                                         444: {b'FLAGS': [b'foo']}}):
             out = self.client.get_flags(sentinel.messages)
-            self.client.fetch.assert_called_with(sentinel.messages, [b'FLAGS'])
+            self.client.fetch.assert_called_with(sentinel.messages, ['FLAGS'])
             self.assertEqual(out, {123: [b'foo', b'bar'],
                                    444: [b'foo']})
 
@@ -49,14 +52,14 @@ class TestFlags(IMAPClientTest):
 
     def _check(self, meth, expected_command, silent=False):
         if silent:
-            expected_command += ".SILENT"
+            expected_command += b".SILENT"
 
         cc = self.client._command_and_check
         cc.return_value = [
-            '11 (FLAGS (blah foo) UID 1)',
-            '11 (UID 1 OTHER (dont))',
-            '22 (FLAGS (foo) UID 2)',
-            '22 (UID 2 OTHER (care))',
+            b'11 (FLAGS (blah foo) UID 1)',
+            b'11 (UID 1 OTHER (dont))',
+            b'22 (FLAGS (foo) UID 2)',
+            b'22 (UID 2 OTHER (care))',
         ]
         resp = meth([1, 2], 'foo', silent=silent)
         cc.assert_called_once_with(
@@ -104,14 +107,14 @@ class TestGmailLabels(IMAPClientTest):
 
     def _check(self, meth, expected_command, silent=False):
         if silent:
-            expected_command += ".SILENT"
+            expected_command += b".SILENT"
 
         cc = self.client._command_and_check
         cc.return_value = [
-            '11 (X-GM-LABELS (blah "f\\"o\\"o") UID 1)',
-            '22 (X-GM-LABELS ("f\\"o\\"o") UID 2)',
-            '11 (UID 1 FLAGS (dont))',
-            '22 (UID 2 FLAGS (care))',
+            b'11 (X-GM-LABELS (blah "f\\"o\\"o") UID 1)',
+            b'22 (X-GM-LABELS ("f\\"o\\"o") UID 2)',
+            b'11 (UID 1 FLAGS (dont))',
+            b'22 (UID 2 FLAGS (care))',
         ]
         resp = meth([1, 2], 'f"o"o', silent=silent)
         cc.assert_called_once_with(

--- a/imapclient/test/test_thread.py
+++ b/imapclient/test/test_thread.py
@@ -4,7 +4,10 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from .imapclient_test import IMAPClientTest
 

--- a/imapclient/test/testable_imapclient.py
+++ b/imapclient/test/testable_imapclient.py
@@ -4,7 +4,11 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
 from imapclient.imapclient import IMAPClient
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,12 @@ use_setuptools(version="18.2")
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-MAJ_MIN = sys.version_info[:2]
-IS_PY3 = MAJ_MIN >= (3, 0)
-IS_PY_26_OR_OLDER = MAJ_MIN <= (2, 6)
-IS_PY_34_OR_NEWER = MAJ_MIN >= (3, 4)
+MAJ_MIN_MIC = sys.version_info[:3]
+IS_PY3 = MAJ_MIN_MIC >= (3, 0, 0)
+IS_PY_26_OR_OLDER = MAJ_MIN_MIC <= (2, 6, 0)
+IS_PY_278_OR_OLDER = MAJ_MIN_MIC <= (2, 7, 8)
+IS_PY_33_OR_OLDER = MAJ_MIN_MIC <= (3, 3, 0)
+IS_PY_34_OR_NEWER = MAJ_MIN_MIC >= (3, 4, 0)
 
 # Read version info
 here = path.dirname(__file__)
@@ -64,15 +66,18 @@ class TestDiscoverCommand(TestCommand):
             module = None
         unittest.main(argv=['', 'discover'], module=module)
 
-common_deps = [
-    'six',
-    'mock==1.3.0',
-]
+common_deps = ['six']
 
-main_deps = common_deps + [
-    'backports.ssl>=0.0.9',
-    'pyopenssl>=' + info["min_pyopenssl_version"],
-]
+# mock is available as unittest.mock for Python >= 3.4
+if IS_PY_33_OR_OLDER:
+    common_deps.append('mock>=1.3.0')
+
+main_deps = common_deps[:]
+
+# use shipped ssl module with Python >= (3.4, 2.7.9)
+if IS_PY_33_OR_OLDER or IS_PY_278_OR_OLDER:
+    main_deps.append('backports.ssl>=0.0.9')
+    main_deps.append('pyopenssl>=' + info["min_pyopenssl_version"])
 
 setup_deps = common_deps + ['sphinx']
 


### PR DESCRIPTION
Hi Menno,

here's an attempt to adjust IMAPClient to the demands of Python 3.4. 
I tried to be careful with respect of backwards compatibility, without sacrifying the new achievements of Python 2.7.9 and 3.4 in terms of ssl. 

In that course, I decided to depend on the importability of backports.ssl. I expect, that current Python installations do not install this package, and adjusted setup.py accordingly.

While at it, I fixed the test fallout of 3.4, and removed the dependency on mock, if unittest.mock is available. 

setup.py test succeeds with 2.7.12 and 3.4.5 now.

This is just the initial PR, expect more to come this way, as I've started a project with a strong focus on IMAP last week, and decided to rely on IMAPClient, rather than imaplib.