### PR TITLE
provide default ssl_context, if not given explicitly

### DIFF
--- a/imapclient/datetime_util.py
+++ b/imapclient/datetime_util.py
@@ -50,7 +50,8 @@ def datetime_to_INTERNALDATE(dt):
     """
     if not dt.tzinfo:
         dt = dt.replace(tzinfo=FixedOffset.for_system())
-    return dt.strftime("%d-%b-%Y %H:%M:%S %z")
+    fmt = '%d-' + _SHORT_MONTHS[dt.month] + '-%Y %H:%M:%S %z'
+    return dt.strftime(fmt)
 
 
 # Matches timestamp strings where the time separator is a dot (see

--- a/imapclient/tls.py
+++ b/imapclient/tls.py
@@ -30,8 +30,10 @@ if sys.version_info[0] == 3 and sys.version_info[:2] >= (3, 4) or \
                                           capath=capath,
                                           cadata=cadata)
 
-    wrap_socket = lambda sock, context, host: \
-        context.wrap_socket(sock, server_hostname = host)
+    def wrap_socket(sock, ssl_context, host):
+        if ssl_context is None:
+            ssl_context = create_default_context()
+        return ssl_context.wrap_socket(sock, server_hostname = host)
 
 else:
     # Explicitly check that the required pyOpenSSL is installed. On some


### PR DESCRIPTION
Hi Menno,

here's a minimal invasive fix for a problem, that I stumbled over...

Problem is that datetime_to_INTERNALDATE relies on datetime formatting. datetime.strftime uses localized month abbreviations for %b, that fails in ugly ways for non en locales when calling append() with msg_time...