### PR TITLE
datetime_to_INTERNALDATE: use plain english month abbreviations

### DIFF
--- a/imapclient/datetime_util.py
+++ b/imapclient/datetime_util.py
@@ -50,7 +50,8 @@ def datetime_to_INTERNALDATE(dt):
     """
     if not dt.tzinfo:
         dt = dt.replace(tzinfo=FixedOffset.for_system())
-    return dt.strftime("%d-%b-%Y %H:%M:%S %z")
+    fmt = '%d-' + _SHORT_MONTHS[dt.month] + '-%Y %H:%M:%S %z'
+    return dt.strftime(fmt)
 
 
 # Matches timestamp strings where the time separator is a dot (see


### PR DESCRIPTION
Thanks to frispete (https://github.com/frispete) for the initial patch