### PR TITLE
Officially support Python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ library.
 
 =========================  ========================================
 Current version            1.0.2
-Supported Python versions  2.6, 2.7, 3.3, 3.4 and 3.5
+Supported Python versions  2.6, 2.7, 3.3, 3.4, 3.5 and 3.6
 License                    New BSD
 Project home               http://imapclient.freshfoo.com/
 PyPI                       https://pypi.python.org/pypi/IMAPClient

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -29,7 +29,7 @@ explains IMAP in detail. Other RFCs also apply to various extensions
 to the base protocol. These are referred to in the documentation below
 where relevant.
 
-Python versions 2.6, 2.7, 3.3, 3.4 and 3.5 are officially supported.
+Python versions 2.6, 2.7, 3.3, 3.4, 3.5 and 3.6 are officially supported.
 
 A Simple Example
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ Features:
     * Convenience methods are provided for commonly used functionality.
     * Exceptions are raised when errors occur.
 
-Python versions 2.6, 2.7, 3.3, 3.4 and 3.5 are officially supported.
+Python versions 2.6, 2.7, 3.3, 3.4, 3.5 and 3.6 are officially supported.
 
 IMAPClient includes comprehensive units tests and automated
 functional tests that can be run against a live IMAP server.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,py35
+envlist=py26,py27,py33,py34,py35,py36
 
 # The tests are currently run directly out of the source tree.
 # See the notes in build-sdist for more details.


### PR DESCRIPTION
We successfully run imapclient with Python 3.6 on production for a few months already.