### PR TITLE
Use the standard logging module

### DIFF
--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -258,6 +258,23 @@ TLS Support
 .. automodule:: imapclient.tls
    :members:
 
+Logging
+~~~~~~~
+IMAPClient logs debug lines using the standard Python `logging module
+<https://docs.python.org/3/library/logging.html>`_. Its logger is
+``imapclient.*``.
+
+A simple way to display log messages is to setup logging::
+
+  import logging
+
+  logging.basicConfig(
+      format='%(asctime)s - %(levelname)s: %(message)s',
+      level=logging.DEBUG
+  )
+
+For advanced usage please refer to the Python documentation.
+
 Interactive Sessions
 --------------------
 When developing program using IMAPClient is it sometimes useful to

--- a/doc/src/releases.rst
+++ b/doc/src/releases.rst
@@ -7,6 +7,8 @@
 Changed
 -------
 - XXX Use built-in TLS when sensible.
+- Logs are now handled by the Python logging module. `debug` and `log_file`
+  are not used anymore.
 
 Other
 -----

--- a/imapclient/test/test_imapclient.py
+++ b/imapclient/test/test_imapclient.py
@@ -8,6 +8,7 @@ import itertools
 import socket
 import sys
 from datetime import datetime
+import logging
 
 import six
 
@@ -349,19 +350,11 @@ class TestIdleAndNoop(IMAPClientTest):
 
 class TestDebugLogging(IMAPClientTest):
 
-    def test_default_is_stderr(self):
-        self.assertIs(self.client.log_file, sys.stderr)
-
     def test_IMAP_is_patched(self):
-        log = six.StringIO()
-        self.client.log_file = log
-
-        self.client._log('one')
+        log_stream = six.StringIO()
+        logging.basicConfig(stream=log_stream, level=logging.DEBUG)
         self.client._imap._mesg('two')
-
-        output = log.getvalue()
-        self.assertIn('one', output)
-        self.assertIn('two', output)
+        self.assertIn('DEBUG:imaplib:two', log_stream.getvalue())
 
 
 class TestTimeNormalisation(IMAPClientTest):

--- a/imapclient/test/testable_imapclient.py
+++ b/imapclient/test/testable_imapclient.py
@@ -24,7 +24,6 @@ class MockIMAP4(Mock):
         self.use_uid = True
         self.sent = b''  # Accumulates what was given to send()
         self.tagged_commands = {}
-        self.debug = 0
         self._starttls_done = False
 
     def send(self, data):


### PR DESCRIPTION
Instead of a custom way of managing log lines, this commit
leverages the standard logging module. As IMAPClient is a library,
the only thing to do is to create a logger and log away.

The final user of IMAPClient is now in charge of formatting,
writing to files or discarding log lines.