### PR TITLE
Use six instead of try/except for ConfigParser import

### DIFF
--- a/imapclient/config.py
+++ b/imapclient/config.py
@@ -4,16 +4,11 @@
 
 from __future__ import unicode_literals
 
-# TODO: can't six do this for us?
-try:
-    from ConfigParser import SafeConfigParser, NoOptionError
-except ImportError:
-    from configparser import SafeConfigParser, NoOptionError
-
 from os import path
 from backports import ssl
 
 from six import iteritems
+from six.moves.configparser import SafeConfigParser, NoOptionError
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.parse import urlencode
 


### PR DESCRIPTION
To reply to the deleted comment `# TODO: can't six do this for us?` in the codebase, yes we can.