### PR TITLE
#141 - Use precise exceptions for each type of error

### DIFF
--- a/doc/src/api.rst
+++ b/doc/src/api.rst
@@ -18,18 +18,27 @@ are encountered during parsing.
 
 Exceptions
 ~~~~~~~~~~
-The following exceptions may be raised by IMAPClient directly. They
-are attached to the IMAPClient class.
+IMAPClient wraps exceptions raised by imaplib to ease the error handling. 
+All the exceptions related to IMAP errors are defined in the module 
+`imapclient.exceptions`. The following general exceptions may be raised:
 
-* IMAPClient.Error: the base class for IMAPClient's exceptions and the
+* IMAPClientException: the base class for IMAPClient's exceptions and the
   most commonly used error.
-* IMAPClient.AbortError: raised if a serious error has occurred that
+* IMAPClientAbortError: raised if a serious error has occurred that
   means the IMAP connection is no longer usable. The connection should
   be dropped without logout if this occurs.
-* IMAPClient.ReadOnlyError: raised if a modifying operation was
+* IMAPClientReadOnlyError: raised if a modifying operation was
   attempted on a read-only folder.
 
-Exceptions from lower network layers are also possible, in particular:
+
+More specific exceptions existed for common known errors:
+
+.. automodule:: imapclient.exceptions
+    :members:
+
+
+Exceptions from lower layers are possible, such as networks error or unicode
+malformed exception. In particular:
 
 * socket.error
 * socket.timeout: raised if a timeout was specified when creating the

--- a/imapclient/exceptions.py
+++ b/imapclient/exceptions.py
@@ -1,0 +1,38 @@
+import imaplib
+
+# Base class allowing to catch any IMAPClient related exceptions
+# To ensure backward compatibility, we "rename" the imaplib general
+# exception class, so we can catch its exceptions without having to
+# deal with it in IMAPClient codebase
+IMAPClientException = imaplib.IMAP4.error
+IMAPClientAbortError = imaplib.IMAP4.abort
+IMAPClientReadOnlyError = imaplib.IMAP4.readonly
+
+
+class CapabilityError(IMAPClientException):
+    """ 
+    The command tried by the user needs a capability not installed 
+    on the IMAP server
+    """
+
+
+class LoginError(IMAPClientException):
+    """
+    A connection has been established with the server but an error 
+    occurred during the authentication.
+    """
+
+
+class IllegalStateException(IMAPClientException):
+    """
+    The command tried needs a different state to be executed. This
+    means the user is not logged in or the command needs a folder to
+    be selected.
+    """
+
+
+class InvalidCriteriaException(IMAPClientException):
+    """ 
+    A command using a search criteria failed, probably due to a syntax 
+    error in the criteria string.
+    """

--- a/livetest.py
+++ b/livetest.py
@@ -19,6 +19,7 @@ from email.utils import make_msgid
 from six import binary_type, text_type, PY3, iteritems
 
 from imapclient.config import parse_config_file, create_client_from_config
+from imapclient.exceptions import IMAPClientException
 from imapclient.fixed_offset import FixedOffset
 from imapclient.imapclient import IMAPClient, DELETED, RECENT, _dict_bytes_normaliser
 from imapclient.response_types import Envelope, Address
@@ -129,7 +130,7 @@ class _TestBase(unittest.TestCase):
         # delete the currently selected folder.
         try:
             self.client.close_folder()
-        except IMAPClient.Error:
+        except IMAPClientException:
             pass
 
         self.client.folder_encode = False
@@ -139,7 +140,7 @@ class _TestBase(unittest.TestCase):
         for folder in folder_names:
             try:
                 self.client.delete_folder(folder)
-            except IMAPClient.Error:
+            except IMAPClientException:
                 if not self.is_fastmail():
                     raise
         self.client.folder_encode = True
@@ -337,7 +338,7 @@ class TestGeneral(_TestBase):
         # Exchange doesn't return an error when subscribing to a
         # non-existent folder
         if not self.is_exchange():
-            self.assertRaises(IMAPClient.Error,
+            self.assertRaises(IMAPClientException,
                               self.client.subscribe_folder,
                               'this folder is not likely to exist')
 
@@ -930,7 +931,7 @@ def quiet_logout(client):
     """
     try:
         client.logout()
-    except IMAPClient.Error:
+    except IMAPClientException:
         pass
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 
 from imapclient import IMAPClient
+from imapclient.exceptions import LoginError
 from .imapclient_test import IMAPClientTest
 
 
@@ -25,7 +26,7 @@ class TestPlainLogin(IMAPClientTest):
 
     def test_fail(self):
         self.client._imap.authenticate.return_value = ('NO', [b'Boom'])
-        self.assertRaises(IMAPClient.Error, self.client.plain_login, "user", "secret")
+        self.assertRaises(LoginError, self.client.plain_login, "user", "secret")
 
     def test_with_authorization_identity(self):
         self.client._imap.authenticate.return_value = ('OK', [b'Success'])

--- a/tests/test_enable.py
+++ b/tests/test_enable.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 from mock import Mock
 
 from imapclient import IMAPClient
+from imapclient.exceptions import IllegalStateException
 from .imapclient_test import IMAPClientTest
 
 
@@ -64,7 +65,7 @@ class TestEnable(IMAPClientTest):
         self.client._imap.state = 'SELECTED'
 
         self.assertRaises(
-            IMAPClient.Error,
+            IllegalStateException,
             self.client.enable,
             'FOO',
         )

--- a/tests/test_imapclient.py
+++ b/tests/test_imapclient.py
@@ -12,8 +12,10 @@ import logging
 
 import six
 
+from imapclient.exceptions import CapabilityError, IMAPClientException
 from imapclient.imapclient import IMAPlibLoggerAdapter
 from imapclient.fixed_offset import FixedOffset
+
 from .testable_imapclient import TestableIMAPClient as IMAPClient
 from .imapclient_test import IMAPClientTest
 from .util import patch, sentinel, Mock
@@ -47,11 +49,11 @@ class TestListFolders(IMAPClientTest):
 
     def test_list_folders_NO(self):
         self.client._imap._simple_command.return_value = ('NO', [b'badness'])
-        self.assertRaises(IMAPClient.Error, self.client.list_folders)
+        self.assertRaises(IMAPClientException, self.client.list_folders)
 
     def test_list_sub_folders_NO(self):
         self.client._imap._simple_command.return_value = ('NO', [b'badness'])
-        self.assertRaises(IMAPClient.Error, self.client.list_folders)
+        self.assertRaises(IMAPClientException, self.client.list_folders)
 
     def test_utf7_decoding(self):
         self.client._imap._simple_command.return_value = ('OK', [b'something'])
@@ -525,7 +527,7 @@ class TestId(IMAPClientTest):
 
     def test_no_support(self):
         self.client._cached_capabilities = (b'IMAP4rev1',)
-        self.assertRaises(ValueError, self.client.id_)
+        self.assertRaises(CapabilityError, self.client.id_)
 
     def test_invalid_parameters(self):
         self.assertRaises(TypeError, self.client.id_, 'bananarama')

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,6 +8,7 @@ from datetime import date, datetime
 
 import imaplib
 
+from imapclient.exceptions import InvalidCriteriaException
 from imapclient.imapclient import _quoted
 from .imapclient_test import IMAPClientTest
 from .util import Mock
@@ -80,7 +81,7 @@ class TestSearch(TestSearchBase):
         self.assertEqual(result.modseq, 51101)
 
     def test_nested_empty(self):
-        self.assertRaises(ValueError, self.client.search, [[]])
+        self.assertRaises(InvalidCriteriaException, self.client.search, [[]])
 
     def test_single(self):
         self.client.search([['FOO']])

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -4,6 +4,8 @@
 
 from __future__ import unicode_literals
 
+from imapclient.exceptions import CapabilityError
+
 from .imapclient_test import IMAPClientTest
 from .util import Mock
 
@@ -22,7 +24,7 @@ class TestSort(IMAPClientTest):
 
     def test_no_support(self):
         self.client._cached_capabilities = (b'BLAH',)
-        self.assertRaises(ValueError, self.client.sort, 'ARRIVAL')
+        self.assertRaises(CapabilityError, self.client.sort, 'ARRIVAL')
 
     def test_single_criteria(self):
         ids = self.client.sort('arrival')

--- a/tests/test_starttls.py
+++ b/tests/test_starttls.py
@@ -5,6 +5,8 @@
 from __future__ import unicode_literals
 
 from imapclient.imapclient import IMAPClient
+from imapclient.exceptions import IMAPClientException
+
 from .imapclient_test import IMAPClientTest
 from .util import Mock, patch, sentinel
 
@@ -44,7 +46,7 @@ class TestStarttls(IMAPClientTest):
     def test_command_fails(self):
         self.client._imap._simple_command.return_value = "NO", [b'sorry']
 
-        with self.assertRaises(IMAPClient.Error) as raised:
+        with self.assertRaises(IMAPClientException) as raised:
             self.client.starttls(sentinel.ssl_context)
         self.assertEqual(str(raised.exception), "starttls failed: sorry")
 

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -4,6 +4,8 @@
 
 from __future__ import unicode_literals
 
+from imapclient.exceptions import CapabilityError
+
 from .imapclient_test import IMAPClientTest
 from .util import Mock
 
@@ -22,11 +24,11 @@ class TestThread(IMAPClientTest):
 
     def test_no_thread_support(self):
         self.client._cached_capabilities = (b'NOT-THREAD',)
-        self.assertRaises(ValueError, self.client.thread)
+        self.assertRaises(CapabilityError, self.client.thread)
 
     def test_unsupported_algorithm(self):
         self.client._cached_capabilities = (b'THREAD=FOO',)
-        self.assertRaises(ValueError, self.client.thread)
+        self.assertRaises(CapabilityError, self.client.thread)
 
     def test_defaults(self):
         threads = self.client.thread()

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+from imapclient.exceptions import InvalidCriteriaException
 from imapclient.imapclient import (
     join_message_ids,
     _normalise_search_criteria,
@@ -161,7 +162,7 @@ class Test_normalise_search_criteria(unittest.TestCase):
         self.check('foo bar', None, [b'foo bar'])
 
     def test_None(self):
-        self.assertRaises(ValueError, _normalise_search_criteria, None, None)
+        self.assertRaises(InvalidCriteriaException, _normalise_search_criteria, None, None)
 
     def test_empty(self):
-        self.assertRaises(ValueError, _normalise_search_criteria, '', None)
+        self.assertRaises(InvalidCriteriaException, _normalise_search_criteria, '', None)


### PR DESCRIPTION
This is a quick draft but I want a first approval before continuing this way, since it will require a lot of code to adapt.

I have defined a new module `imapclient.exceptions` that defines all types of exceptions that IMAPClient might raise. This is very similar [to what requests/django/pytz are doing](https://github.com/requests/requests/blob/master/requests/exceptions.py). The base class is actually just `imap.IMAP4.error` so we can still rely on `except imap.IMAP4.error` if we don't care at all about the source of the exception (+ backward compatibility with 1.x code) 

The most-time consuming is now to define what exceptions we need (I wrote down a couple of them) and raise them in the appropriate methods. 
Most of the exceptions raised in IMAPClient are actually exceptions that bubble up from imaplib itself. So we might need to catch them and re-raise with our more dedicated exception to make debugging and error handling more efficient for IMAPClient users.
