### PR TITLE
allow EXPUNGE by ID

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1089,7 +1089,7 @@ class IMAPClient(object):
                                        self._normalise_folder(folder),
                                        uid=True, unpack=True)
 
-    def expunge(self):
+    def expunge(self, messages=None):
         """Remove any messages from the currently selected folder that
         have the ``\\Deleted`` flag set.
 
@@ -1108,6 +1108,10 @@ class IMAPClient(object):
         See :rfc:`3501#section-6.4.3` section 6.4.3 and
         :rfc:`3501#section-7.4.1` section 7.4.1 for more details.
         """
+        if messages:
+          if not self.use_uid:
+            raise ValueError('cannot EXPUNGE by ID when not using uids')
+          return self._command_and_check('EXPUNGE', join_message_ids(messages), uid=True)
         tag = self._imap._command('EXPUNGE')
         return self._consume_until_tagged_response(tag, 'EXPUNGE')
 

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1120,9 +1120,9 @@ class IMAPClient(object):
         See :rfc:`4315#section-2.1` section 2.1 for more details.
         """
         if messages:
-          if not self.use_uid:
-            raise ValueError('cannot EXPUNGE by ID when not using uids')
-          return self._command_and_check('EXPUNGE', join_message_ids(messages), uid=True)
+            if not self.use_uid:
+                raise ValueError('cannot EXPUNGE by ID when not using uids')
+            return self._command_and_check('EXPUNGE', join_message_ids(messages), uid=True)
         tag = self._imap._command('EXPUNGE')
         return self._consume_until_tagged_response(tag, 'EXPUNGE')
 

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1090,8 +1090,9 @@ class IMAPClient(object):
                                        uid=True, unpack=True)
 
     def expunge(self, messages=None):
-        """Remove any messages from the currently selected folder that
-        have the ``\\Deleted`` flag set.
+        """When, no *messages* are specified, remove all messages
+        from the currently selected folder that have the
+        ``\\Deleted`` flag set.
 
         The return value is the server response message
         followed by a list of expunge responses. For example::
@@ -1107,6 +1108,16 @@ class IMAPClient(object):
 
         See :rfc:`3501#section-6.4.3` section 6.4.3 and
         :rfc:`3501#section-7.4.1` section 7.4.1 for more details.
+
+        When *messages* are specified, remove the specified messages
+        from the selected folder, provided those messages also have
+        the ``\\Deleted`` flag set. The return value is ``None`` in
+        this case.
+
+        Expunging messages by id(s) requires that *use_uid* is
+        ``True`` for the client.
+
+        See :rfc:`4315#section-2.1` section 2.1 for more details.
         """
         if messages:
           if not self.use_uid:

--- a/imapclient/livetest.py
+++ b/imapclient/livetest.py
@@ -918,6 +918,26 @@ def createUidTestClass(conf, use_uid):
                 # on. EXPUNGE won't return anything in this case
                 self.assertIn((1, b'EXPUNGE'), resps)
 
+        def test_id_expunge(self):
+          if not self.client.use_uid:
+            self.skipTest('test instance not configured for UID operations')
+          folder = self.add_prefix_to_folder('test_id_expunge')
+          self.client.create_folder(folder)
+          self.client.select_folder(folder)
+          for i in range(3):
+            self.client.append(folder, 'Subject: msg %d\r\n\r\nbody %d\r\n\r\n' % (i, i))
+          messages = self.client.search()
+          self.assertEquals(len(messages), 3)
+          m0 = messages[0]
+          m1 = messages[1]
+          # delete 2 messages, but only expunge one of them
+          self.client.delete_messages([messages[0], messages[2]])
+          ret = self.client.expunge(messages[2])
+          messages = self.client.search()
+          self.assertEquals(len(messages), 2)
+          self.assertIn(m0, messages)
+          self.assertIn(m1, messages)
+
         def test_getacl(self):
             self.skip_unless_capable('ACL')
 

--- a/imapclient/livetest.py
+++ b/imapclient/livetest.py
@@ -919,24 +919,24 @@ def createUidTestClass(conf, use_uid):
                 self.assertIn((1, b'EXPUNGE'), resps)
 
         def test_id_expunge(self):
-          if not self.client.use_uid:
-            self.skipTest('test instance not configured for UID operations')
-          folder = self.add_prefix_to_folder('test_id_expunge')
-          self.client.create_folder(folder)
-          self.client.select_folder(folder)
-          for i in range(3):
-            self.client.append(folder, 'Subject: msg %d\r\n\r\nbody %d\r\n\r\n' % (i, i))
-          messages = self.client.search()
-          self.assertEquals(len(messages), 3)
-          m0 = messages[0]
-          m1 = messages[1]
-          # delete 2 messages, but only expunge one of them
-          self.client.delete_messages([messages[0], messages[2]])
-          ret = self.client.expunge(messages[2])
-          messages = self.client.search()
-          self.assertEquals(len(messages), 2)
-          self.assertIn(m0, messages)
-          self.assertIn(m1, messages)
+            if not self.client.use_uid:
+                self.skipTest('test instance not configured for UID operations')
+            folder = self.add_prefix_to_folder('test_id_expunge')
+            self.client.create_folder(folder)
+            self.client.select_folder(folder)
+            for i in range(3):
+                self.client.append(folder, 'Subject: msg %d\r\n\r\nbody %d\r\n\r\n' % (i, i))
+            messages = self.client.search()
+            self.assertEqual(len(messages), 3)
+            m0 = messages[0]
+            m1 = messages[1]
+            # delete 2 messages, but only expunge one of them
+            self.client.delete_messages([messages[0], messages[2]])
+            ret = self.client.expunge(messages[2])
+            messages = self.client.search()
+            self.assertEqual(len(messages), 2)
+            self.assertIn(m0, messages)
+            self.assertIn(m1, messages)
 
         def test_getacl(self):
             self.skip_unless_capable('ACL')

--- a/imapclient/test/test_imapclient.py
+++ b/imapclient/test/test_imapclient.py
@@ -578,6 +578,21 @@ class TestRawCommand(IMAPClientTest):
         with self.assertRaisesRegex(IMAPClient.AbortError, expected_error):
             self.client._raw_command(b'FOO', [b'\xff'])
 
+class TestExpunge(IMAPClientTest):
+
+    def test_expunge(self):
+        mockCommand = Mock(return_value=sentinel.tag)
+        mockConsume = Mock(return_value=sentinel.out)
+        self.client._imap._command = mockCommand
+        self.client._consume_until_tagged_response = mockConsume
+        result = self.client.expunge()
+        mockCommand.assert_called_with('EXPUNGE')
+        mockConsume.assert_called_with(sentinel.tag, 'EXPUNGE')
+        self.assertEqual(sentinel.out, result)
+
+    def test_id_expunge(self):
+        self.client._imap.uid.return_value = ('OK', [None])
+        self.assertEqual([None], self.client.expunge(['4','5', '6']))
 
 class TestShutdown(IMAPClientTest):
 


### PR DESCRIPTION
Patch to allow EXPUNGE by ID, and avoid the problem where folder-wide expunge deletes all messages.

Implements one item on the list for https://github.com/mjs/imapclient/issues/36

The idea is to overload arguments to expunge(): if messages are specified, do a `'UID EXPUNGE <messages>'`, else it is a folder-wide expunge(). The former won't work if `use_uid=False`. (I don't have insight how many IMAPClient users turn off uid's, and whether this would be better as a different method).

The return type is None when expunge-ing by id. imaplib.py returns `('OK', [None])` from a `UID EXPUNGE`.