### PR TITLE
#285 - Separate connect timeout from read/write timeout

### DIFF
--- a/doc/src/api.rst
+++ b/doc/src/api.rst
@@ -7,6 +7,9 @@ IMAPClient instance.
 .. autoclass:: imapclient.IMAPClient
    :members:
 
+.. autoclass:: imapclient.SocketTimeout
+   :members:
+
 Fetch Response Types
 ~~~~~~~~~~~~~~~~~~~~
 Various types may be used in the data structures returned by

--- a/doc/src/releases.rst
+++ b/doc/src/releases.rst
@@ -4,14 +4,19 @@
  Version 2.0
 =============
 
+Added
+-----
+- Connection and read/write operations timeout can now be distinct, 
+  using `imapclient.SocketTimeout` namedtuple as `timeout` parameter.
+- A context manager is introduced to automatically close connections to remote
+  servers.
+
 Changed
 -------
 - Connections to servers use SSL/TLS by default (`ssl=True`)
 - XXX Use built-in TLS when sensible.
 - Logs are now handled by the Python logging module. `debug` and `log_file`
   are not used anymore.
-- A context manager is introduced to automatically close connections to remote
-  servers.
 - More precise exceptions available in `imapclient.exceptions` are raised when
   an error happens
 

--- a/imapclient/config.py
+++ b/imapclient/config.py
@@ -154,7 +154,7 @@ def get_oauth2_token(hostname, client_id, client_secret, refresh_token):
     _oauth2_cache[cache_key] = token
     return token
 
-def create_client_from_config(conf):
+def create_client_from_config(conf, login=True):
     assert conf.host, "missing host"
 
     ssl_context = None
@@ -171,6 +171,9 @@ def create_client_from_config(conf):
                                    ssl_context=ssl_context,
                                    stream=conf.stream,
                                    timeout=conf.timeout)
+    if not login:
+        return client
+
     try:
         if conf.starttls:
             client.starttls()

--- a/imapclient/imap4.py
+++ b/imapclient/imap4.py
@@ -13,4 +13,4 @@ class IMAP4WithTimeout(imaplib.IMAP4):
         imaplib.IMAP4.__init__(self, address, port)
 
     def _create_socket(self):
-        return socket.create_connection((self.host, self.port), self._timeout)
+        return socket.create_connection((self.host, self.port), self._timeout.connect)

--- a/imapclient/tls.py
+++ b/imapclient/tls.py
@@ -213,7 +213,7 @@ class IMAP4_TLS(imaplib.IMAP4):
     def open(self, host, port):
         self.host = host
         self.port = port
-        sock = socket.create_connection((host, port), self._timeout)
+        sock = socket.create_connection((host, port), self._timeout.connect)
         self.sock = wrap_socket(sock, self.ssl_context, host)
         self.file = self.sock.makefile('rb')
 

--- a/tests/test_imapclient.py
+++ b/tests/test_imapclient.py
@@ -248,6 +248,7 @@ class TestIdleAndNoop(IMAPClientTest):
             ('settimeout', (None,), {}),
             ('setblocking', (0,), {}),
             ('setblocking', (1,), {}),
+            ('settimeout', (None,), {}),
         ])
 
     def test_idle(self):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,7 @@
 # Released subject to the New BSD License
 # Please see http://en.wikipedia.org/wiki/BSD_licenses
 
-from imapclient.imapclient import IMAPClient
+from imapclient.imapclient import IMAPClient, SocketTimeout
 from .util import unittest, patch, sentinel, Mock
 
 
@@ -30,7 +30,7 @@ class TestInit(unittest.TestCase):
         self.assertEqual(imap._imap, fakeIMAP4)
         self.imap4.IMAP4WithTimeout.assert_called_with(
             '1.2.3.4', 143,
-            sentinel.timeout
+            SocketTimeout(sentinel.timeout, sentinel.timeout)
         )
         self.assertEqual(imap.host, '1.2.3.4')
         self.assertEqual(imap.port, 143)
@@ -48,7 +48,9 @@ class TestInit(unittest.TestCase):
         self.assertEqual(imap._imap, fakeIMAP4_TLS)
         self.tls.IMAP4_TLS.assert_called_with(
             '1.2.3.4', 993,
-            sentinel.context, sentinel.timeout)
+            sentinel.context, 
+            SocketTimeout(sentinel.timeout, sentinel.timeout)
+        )
         self.assertEqual(imap.host, '1.2.3.4')
         self.assertEqual(imap.port, 993)
         self.assertEqual(imap.ssl, True)
@@ -56,11 +58,12 @@ class TestInit(unittest.TestCase):
         self.assertEqual(imap.stream, False)
 
     def test_stream(self):
-        self.imaplib.IMAP4_stream.return_value = sentinel.IMAP4_stream
+        fakeIMAP4_stream = Mock()
+        self.imaplib.IMAP4_stream.return_value = fakeIMAP4_stream
 
         imap = IMAPClient('command', stream=True, ssl=False)
 
-        self.assertEqual(imap._imap, sentinel.IMAP4_stream)
+        self.assertEqual(imap._imap, fakeIMAP4_stream)
         self.imaplib.IMAP4_stream.assert_called_with('command')
 
         self.assertEqual(imap.host, 'command')


### PR DESCRIPTION
Still a WIP, seems to work on my mailbox, further tests would be appreciated. Things to do:

- [x] Implement something backward-compatible to handle single timeout AND two different timeouts
- [x] Add doc about `SocketTimeout` namedtuple
- [x] Check if all types of IMAP connection (plain, TLS, etc) are handled correctly
- [x] Add tests... How?
- [x] Add release notes