### PR TITLE
Add support for UID MOVE (RFC 6851)

### DIFF
--- a/doc/src/releases.rst
+++ b/doc/src/releases.rst
@@ -10,6 +10,8 @@ Added
   using `imapclient.SocketTimeout` namedtuple as `timeout` parameter.
 - A context manager is introduced to automatically close connections to remote
   servers.
+- Atomically move messages to another folder using the MOVE extension
+  (:rfc:`6851`)
 
 Changed
 -------

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -64,6 +64,9 @@ if 'UNSELECT' not in imaplib.Commands:
 if 'ENABLE' not in imaplib.Commands:
     imaplib.Commands['ENABLE'] = ('AUTH',)
 
+# .. and MOVE for RFC6851.
+if 'MOVE' not in imaplib.Commands:
+    imaplib.Commands['MOVE'] = ('AUTH', 'SELECTED')
 
 # System flags
 DELETED = br'\Deleted'
@@ -1162,6 +1165,19 @@ class IMAPClient(object):
         server.
         """
         return self._command_and_check('copy',
+                                       join_message_ids(messages),
+                                       self._normalise_folder(folder),
+                                       uid=True, unpack=True)
+
+    def move(self, messages, folder):
+        """Atomically move messages to another folder.
+
+        Requires the MOVE capability, see :rfc:`6851`.
+
+        :param messages: List of message UIDs to move.
+        :param folder: The destination folder name.
+        """
+        return self._command_and_check('move',
                                        join_message_ids(messages),
                                        self._normalise_folder(folder),
                                        uid=True, unpack=True)

--- a/livetest.py
+++ b/livetest.py
@@ -805,6 +805,25 @@ def createUidTestClass(conf, use_uid):
             msg_id = msgs[0]
             self.assertIn(b'something', self.client.fetch(msg_id, ['RFC822'])[msg_id][b'RFC822'])
 
+        def test_move(self):
+            self.skip_unless_capable('MOVE')
+
+            self.append_msg(SIMPLE_MESSAGE)
+            target_folder = self.add_prefix_to_folder('target')
+            self.client.create_folder(target_folder)
+            found_messages = self.client.search()
+            msg_id = found_messages[0]
+
+            self.client.move(msg_id, target_folder)
+            self.assertEqual(len(self.client.search()),
+                             len(found_messages) - 1)
+
+            self.client.select_folder(target_folder)
+            msgs = self.client.search()
+            self.assertEqual(len(msgs), 1)
+            msg_id = msgs[0]
+            self.assertIn(b'something', self.client.fetch(msg_id, ['RFC822'])[msg_id][b'RFC822'])
+
         def test_fetch(self):
             # Generate a fresh message-id each time because Gmail is
             # clever and will treat appends of messages with


### PR DESCRIPTION
Allows to move messages in a single call without going through
copy + flag deleted + expunge.

Fixes #142