### PR TITLE
Clean up and fix flickering livetest due to config manipulation

### DIFF
--- a/imapclient/config.py
+++ b/imapclient/config.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import json
 from os import environ, path
 
 from backports import ssl
@@ -14,11 +15,6 @@ from six.moves.urllib.parse import urlencode
 
 import imapclient
 from .tls import create_default_context
-
-try:
-    import json
-except ImportError:
-    json = None
 
 
 def getenv(name, default):
@@ -127,9 +123,6 @@ OAUTH2_REFRESH_URLS = {
 }
 
 def refresh_oauth2_token(hostname, client_id, client_secret, refresh_token):
-    if not json:
-        raise RuntimeError("OAUTH2 functionality relies on 'json' module")
-
     url = OAUTH2_REFRESH_URLS.get(hostname)
     if not url:
         raise ValueError("don't know where to refresh OAUTH2 token for %r" % hostname)

--- a/livetest.py
+++ b/livetest.py
@@ -6,6 +6,7 @@
 
 from __future__ import print_function, unicode_literals
 
+import copy
 import imp
 import os
 import random
@@ -1051,7 +1052,7 @@ def main():
         setattr(live_test_mod, name, klass)
 
     TestGeneral.conf = host_config
-    TestSocketTimeout.conf = host_config
+    TestSocketTimeout.conf = copy.copy(host_config)
     add_test_class(TestGeneral)
     add_test_class(TestSocketTimeout)
     add_test_class(createUidTestClass(host_config, use_uid=True), 'TestWithUIDs')


### PR DESCRIPTION
Both commits are really cleanup routine, they should be self-explanatory 