### PR TITLE
quote empty strings as otherwise they would be ignored by the server

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1459,7 +1459,7 @@ class _quoted(binary_type):
         """
         quoted = original.replace(b'\\', b'\\\\')
         quoted = quoted.replace(b'"', b'\\"')
-        if quoted != original or b' ' in quoted:
+        if quoted != original or b' ' in quoted or not quoted:
             out = cls(b'"' + quoted + b'"')
             out.original = original
             return out

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -99,6 +99,10 @@ class TestSearch(TestSearchBase):
         self.client.search(['NOT', ('SUBJECT', 'topic',  'TO', 'some@email.com')])
         self.check_call([b'NOT', b'(SUBJECT', b'topic', b'TO', b'some@email.com)'])
 
+    def test_quote_empty_strings(self):
+        self.client.search(['HEADER', 'List-Id', ''])
+        self.check_call([b'HEADER', b'List-Id', b'""'])
+
     def test_search_custom_exception_with_invalid_list(self):
         def search_bad_command_exp(*args, **kwargs):
             raise imaplib.IMAP4.error('SEARCH command error: BAD ["Unknown argument NOT DELETED"]')

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -64,6 +64,10 @@ class TestSearch(TestSearchBase):
         self.client.search(['TEXT', 'foo bar'])
         self.check_call([b'TEXT', _quoted(b'"foo bar"')])
 
+        # Zero-length strings should be quoted
+        self.client.search(['HEADER', 'List-Id', ''])
+        self.check_call([b'HEADER', b'List-Id', b'""'])
+
     def test_no_results(self):
         self.client._raw_command_untagged.return_value = [None]
 
@@ -98,10 +102,6 @@ class TestSearch(TestSearchBase):
     def test_nested_tuple(self):
         self.client.search(['NOT', ('SUBJECT', 'topic',  'TO', 'some@email.com')])
         self.check_call([b'NOT', b'(SUBJECT', b'topic', b'TO', b'some@email.com)'])
-
-    def test_quote_empty_strings(self):
-        self.client.search(['HEADER', 'List-Id', ''])
-        self.check_call([b'HEADER', b'List-Id', b'""'])
 
     def test_search_custom_exception_with_invalid_list(self):
         def search_bad_command_exp(*args, **kwargs):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -64,6 +64,7 @@ class TestSearch(TestSearchBase):
         self.client.search(['TEXT', 'foo bar'])
         self.check_call([b'TEXT', _quoted(b'"foo bar"')])
 
+    def test_zero_length_quoting(self):
         # Zero-length strings should be quoted
         self.client.search(['HEADER', 'List-Id', ''])
         self.check_call([b'HEADER', b'List-Id', b'""'])


### PR DESCRIPTION
I've run into a problem when using the search criterion `HEADER`. As [RFC 3501](https://tools.ietf.org/html/rfc3501#section-6.4.4) tells us the syntax is `HEADER <field-name> <string>`. It also says: " If the string to search is zero-length, this matches all messages that have a header line with the specified field-name regardless of the contents."
When you issue `server.search(['HEADER', 'List-Id', ''])` the zero-length argument is ignored resulting in a syntax error.

This pull request fixes this problem. I do not know whether this is the right place to fix this problem but if so I would be glad if the PR could be merged.