### PR TITLE
Allow old version of Python 2.7 to use TLS

### DIFF
--- a/doc/src/concepts.rst
+++ b/doc/src/concepts.rst
@@ -89,6 +89,13 @@ When constructing a custom context it is usually best to start with
 the default context, created by the ``ssl`` module, and modify it to
 suit your needs.
 
+.. warning::
+
+  Users of Python 2.7.0 - 2.7.8 can use TLS but cannot configure
+  the settings via an ``ssl.SSLContext``. These Python versions are
+  also not capable of proper certification verification. It is highly
+  encouraged to upgrade to a more recent version of Python.
+
 The following example shows how to to disable certification
 verification and certificate host name checks if required.
 
@@ -111,18 +118,6 @@ a list of common and respectable CAs::
 The above examples show some of the most common TLS parameter
 customisations but there are many other tweaks are possible. Consult
 the Python 3 :py:mod:`ssl` package documentation for further options.
-
-Old pyOpenSSL Versions
-+++++++++++++++++++++++
-
-IMAPClient's TLS functionality will not behaviour correctly if an
-out-of-date version of pyOpenSSL is used. On some systems
-(particularly OS X) the system installed version of pyOpenSSL will
-take precedence over any user installed version. Use of virtualenvs is
-strongly encouraged to work around this.
-
-IMAPClient checks the installed pyOpenSSL version at import time and
-will fail early if an old pyOpenSSL version is found.
 
 Using gevent with IMAPClient
 ++++++++++++++++++++++++++++

--- a/imapclient/tls.py
+++ b/imapclient/tls.py
@@ -13,6 +13,19 @@ import ssl
 
 
 def wrap_socket(sock, ssl_context, host):
+
+    if not hasattr(ssl, 'create_default_context'):
+        # Python 2.7.0 - 2.7.8 do not have the concept of ssl contexts.
+        # Thus we have to use the less flexible and legacy way of wrapping the
+        # socket
+        if ssl_context is not None:
+            raise RuntimeError(
+                "Cannot precisely configure the SSL connection, upgrade to "
+                "Python >= 2.7.9 to fine tune the settings."
+            )
+
+        return ssl.wrap_socket(sock)
+
     if ssl_context is None:
         ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
 

--- a/imapclient/version.py
+++ b/imapclient/version.py
@@ -21,5 +21,3 @@ maintainer_email = 'imapclient@groups.io'
 
 author = 'Menno Finlay-Smits'
 author_email = 'inbox@menno.io'
-
-min_pyopenssl_version = '0.15.1'


### PR DESCRIPTION
The modern implementation of ssl using SSLContext appeared in
Python 2.7.9. Previous versions can use encrypted connections but
cannot precisely configure it.

Fixes #301