### PR TITLE
Handle GMail labels with international characters

### DIFF
--- a/doc/src/releases.rst
+++ b/doc/src/releases.rst
@@ -19,6 +19,11 @@ Changed
   are not used anymore.
 - More precise exceptions available in `imapclient.exceptions` are raised when
   an error happens
+- GMail labels are now strings instead of bytes in Python 3.
+
+Fixed
+-----
+- GMail labels using international characters are now handled properly.
 
 Other
 -----

--- a/livetest.py
+++ b/livetest.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright (c) 2014, Menno Smits
 # Released subject to the New BSD License
@@ -623,9 +624,9 @@ def createUidTestClass(conf, use_uid):
                 actual_labels = set(answer[msg_id])
                 self.assertSetEqual(actual_labels, set(expected_labels))
 
-            FOO = b'_imapclient_foo'
-            BAR = b'_imapclient_bar'
-            BAZ = b'_imapclient_baz'
+            FOO = '_imapclient_foo'
+            BAR = '_imapclient_bar'
+            BAZ = u'_imapclient_bÂz'
             all_labels = [FOO, BAR, BAZ]
             base_labels = [FOO, BAR]
             try:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2016, Menno Smits
 # Released subject to the New BSD License
 # Please see http://en.wikipedia.org/wiki/BSD_licenses
@@ -82,12 +83,12 @@ class TestGmailLabels(IMAPClientTest):
 
     def test_get(self):
         with patch.object(self.client, 'fetch', autospec=True,
-                          return_value={123: {b'X-GM-LABELS': [b'foo', b'bar']},
+                          return_value={123: {b'X-GM-LABELS': [b'foo', b'&AUE-abel']},
                                         444: {b'X-GM-LABELS': [b'foo']}}):
             out = self.client.get_gmail_labels(sentinel.messages)
             self.client.fetch.assert_called_with(sentinel.messages, [b'X-GM-LABELS'])
-            self.assertEqual(out, {123: [b'foo', b'bar'],
-                                   444: [b'foo']})
+            self.assertEqual(out, {123: ['foo', u'Łabel'],
+                                   444: ['foo']})
 
     def test_set(self):
         self.check(self.client.set_gmail_labels, b'X-GM-LABELS')
@@ -108,7 +109,7 @@ class TestGmailLabels(IMAPClientTest):
 
         cc = self.client._command_and_check
         cc.return_value = [
-            b'11 (X-GM-LABELS (blah "f\\"o\\"o") UID 1)',
+            b'11 (X-GM-LABELS (&AUE-abel "f\\"o\\"o") UID 1)',
             b'22 (X-GM-LABELS ("f\\"o\\"o") UID 2)',
             b'11 (UID 1 FLAGS (dont))',
             b'22 (UID 2 FLAGS (care))',
@@ -123,8 +124,8 @@ class TestGmailLabels(IMAPClientTest):
             self.assertIsNone(resp)
         else:
             self.assertEqual(resp, {
-                1: (b'blah', b'f"o"o'),
-                2: (b'f"o"o',),
+                1: [u'Łabel', 'f"o"o'],
+                2: ['f"o"o',],
             })
 
         cc.reset_mock()


### PR DESCRIPTION
Encode/decode GMail labels using UTF-7 so that international
characters are handled correctly.

This has the effect of slightly changing IMAPClient API as labels
are now str in Python 3 and unicode in Python 2.7.

Fixes #181