### PR TITLE
Use correct ssl purpose

### DIFF
--- a/imapclient/config.py
+++ b/imapclient/config.py
@@ -151,7 +151,7 @@ def create_client_from_config(conf, login=True):
 
     ssl_context = None
     if conf.ssl:
-        ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+        ssl_context = ssl.create_default_context()
         ssl_context.check_hostname = conf.ssl_check_hostname
         if not conf.ssl_verify_cert:
             ssl_context.verify_mode = ssl.CERT_NONE

--- a/imapclient/tls.py
+++ b/imapclient/tls.py
@@ -27,7 +27,7 @@ def wrap_socket(sock, ssl_context, host):
         return ssl.wrap_socket(sock)
 
     if ssl_context is None:
-        ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+        ssl_context = ssl.create_default_context()
 
     return ssl_context.wrap_socket(sock, server_hostname=host)
 


### PR DESCRIPTION
The ssl contexts are created to authenticate servers so we should
use `ssl.Purpose.SERVER_AUTH` which is the default.

Fixes #317