### PR TITLE
Fix error when INTERNALDATE is NIL

### DIFF
--- a/imapclient/response_parser.py
+++ b/imapclient/response_parser.py
@@ -160,8 +160,7 @@ def _int_or_error(value, error_text):
 
 
 def _convert_INTERNALDATE(date_string, normalise_times=True):
-    # Observed in https://sentry.nylas.com/sentry/sync-prod/group/5907/
-    if date_string.upper() == b'NIL':
+    if date_string is None:
         return None
 
     try:

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -473,6 +473,15 @@ class TestParseFetchResponse(unittest.TestCase):
             datetime(2007, 2, 9, 17, 8, 8, 0, FixedOffset(-4 * 60 - 30)))
         self.assertEqual(dt, expected_dt)
 
+    def test_INTERNALDATE_NIL(self):
+        out = parse_fetch_response(
+            [b'1 (INTERNALDATE NIL)']
+        )
+        self.assertEqual(
+            out[1][b'INTERNALDATE'],
+            None
+        )
+
     def test_mixed_types(self):
         self.assertEqual(parse_fetch_response([(
             b'1 (INTERNALDATE " 9-Feb-2007 17:08:08 +0100" RFC822 {21}',


### PR DESCRIPTION
NIL is already converted to None during parsing.
The .upper() call on None will cause AttributeError. Catch this case
early and return None early.