### PR TITLE
Catch the right exception in folder_status

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -848,10 +848,7 @@ class IMAPClient(object):
         fname = self._normalise_folder(folder)
         data = self._command_and_check('status', fname, what_)
         response = parse_response(data)
-        try:
-            status_items = response[-1]
-        except IndexError:
-            raise Exception('folder_status IndexError: Input ' + str(response))
+        status_items = response[-1]
         return dict(as_pairs(status_items))
 
     def close_folder(self):

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -850,8 +850,8 @@ class IMAPClient(object):
         response = parse_response(data)
         try:
             status_items = response[-1]
-        except ValueError:
-            raise Exception('folder_status ValueError: Input ' + str(response))
+        except IndexError:
+            raise Exception('folder_status IndexError: Input ' + str(response))
         return dict(as_pairs(status_items))
 
     def close_folder(self):


### PR DESCRIPTION
Not sure why are we catching ValueError here. I don't think it will ever raise ValueError just by assigning list/tuple's index -1 item to a variable. The exception I got from `response[-1]` is IndexError when the response is an empty list. But if we catch IndexError, `str(response)` is certainly empty list/tuple. Do we still want that exception message?