### PR TITLE
Fix _proc_folder_list quadratic runtime

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -25,7 +25,7 @@ from . import tls
 from .datetime_util import datetime_to_INTERNALDATE, format_criteria_date
 from .imap_utf7 import encode as encode_utf7, decode as decode_utf7
 from .response_parser import parse_response, parse_message_list, parse_fetch_response
-from .util import to_bytes, to_unicode, assert_imap_protocol
+from .util import to_bytes, to_unicode, assert_imap_protocol, chunk
 xrange = moves.xrange
 
 if PY3:
@@ -609,11 +609,7 @@ class IMAPClient(object):
 
         ret = []
         parsed = parse_response(folder_data)
-        while parsed:
-            # TODO: could be more efficient
-            flags, delim, name = parsed[:3]
-            parsed = parsed[3:]
-
+        for flags, delim, name in chunk(parsed, size=3):
             if isinstance(name, (int, long)):
                 # Some IMAP implementations return integer folder names
                 # with quotes. These get parsed to ints so convert them

--- a/imapclient/util.py
+++ b/imapclient/util.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import six
 import logging
 from six import binary_type, text_type
 
@@ -37,3 +38,8 @@ def assert_imap_protocol(condition, message=None):
         if message:
             msg += "{}: {}".format(msg, message)
         raise exceptions.ProtocolError(msg)
+
+
+def chunk(lst, size):
+    for i in six.moves.range(0, len(lst), size):
+        yield lst[i:i + size]


### PR DESCRIPTION
Testing / benchmarking script:
```
import time
import timeit
import itertools
import six
import perfplot

time.perf_counter = timeit.default_timer


def chunk_len(lst, n):
    for i in six.moves.range(0, len(lst), n):
        yield lst[i:i + n]


def chunk_iter(iterable, size):
    it = iter(iterable)
    while True:
        chnk = tuple(itertools.islice(it, None, size))
        if not chnk:
            return
        yield chnk


def f1(lst):
    while lst:
        a, b, c = lst[:3]
        # yield a, b, c
        lst = lst[3:]


def f2(lst):
    for a, b, c in chunk_len(lst, 3):
        # yield a, b, c
        pass


def f3(lst):
    for a, b, c in chunk_iter(lst, 3):
        # yield a, b, c
        pass


# x = range(3 * 1000)
# assert list(f1(x)) == list(f2(x)) == list(f3(x))


perfplot.show(
    setup=lambda n: range(n),  # or simply setup=numpy.random.rand
    kernels=[f1, f2, f3],
    labels=['f1', 'f2', 'f3'],
    n_range=[3 * i for i in range(0, 10000, 500)],
    equality_check=None,
    # xlabel='len(a)',
    # More optional arguments with their default values:
    # title=None,
    # logx=True,
    # logy=False,
    # equality_check=numpy.allclose,  # set to None to disable "correctness" assertion
    # automatic_order=True,
    # colors=None,
    # target_time_per_measurement=1.0,
)
```

![image](https://user-images.githubusercontent.com/9133397/54901859-c2570800-4f12-11e9-9ac1-4e47b1a7210a.png)

Although the iterator version is more elegant, I went for the simpler one because the only usage in `_proc_folder_list` uses a tuple, and `f2` is easier to understand (and faster). 