### PR TITLE
2x faster _maybe_int_to_bytes for Python 2

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1601,7 +1601,7 @@ def join_message_ids(messages):
 
 def _maybe_int_to_bytes(val):
     if isinstance(val, integer_types):
-        return str(val).encode('us-ascii')
+        return str(val).encode('us-ascii') if PY3 else str(val)
     return to_bytes(val)
 
 


### PR DESCRIPTION
Python 2.7.12:
```
In [10]: def _maybe_int_to_bytes(val):
    ...:     if isinstance(val, integer_types):
    ...:         return str(val).encode('us-ascii')
    ...:     return to_bytes(val)
    ...: 

In [11]: %timeit _maybe_int_to_bytes(1000)
The slowest run took 15.50 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 585 ns per loop

In [22]: def _maybe_int_to_bytes(val):
    ...:     if isinstance(val, integer_types):
    ...:         return str(val).encode('us-ascii') if PY3 else str(val)
    ...:     return to_bytes(val)
    ...: 

In [25]: %timeit _maybe_int_to_bytes(1000)
The slowest run took 15.67 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 243 ns per loop
```

`_maybe_int_to_bytes()` is executed in a tight loop (i.e. in a generator). E.g. run once for each input message id in fetch command.

Encoding a `str` in python2 doesn't make sense anyway. Negligible performance hit for Python3.