### PR TITLE
Cache regex in _process_select_response

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -99,6 +99,9 @@ _POPULAR_SPECIAL_FOLDERS = {
     JUNK: ("Junk", "Spam")
 }
 
+_RE_SELECT_RESPONSE = re.compile(br'\[(?P<key>[A-Z-]+)( \((?P<data>.*)\))?\]')
+
+
 class Namespace(tuple):
 
     def __new__(cls, personal, other, shared):
@@ -698,7 +701,7 @@ class IMAPClient(object):
         # imaplib doesn't parse these correctly (broken regex) so replace
         # with the raw values out of the OK section
         for line in untagged.get('OK', []):
-            match = re.match(br'\[(?P<key>[A-Z-]+)( \((?P<data>.*)\))?\]', line)
+            match = _RE_SELECT_RESPONSE.match(line)
             if match:
                 key = match.group('key')
                 if key == b'PERMANENTFLAGS':


### PR DESCRIPTION
Cache the regex object explicitly instead of relying on Python `re`'s internal cache. Using `.match` from object instead of `re` skips the checking of internal cache so this change is faster either the internal cache is full or not. Since this is more like a micro-optimization, the benchmark may not be stable but the avg results are definitely better (by at least 10%). After all, it is always more reasonable to explicitly cache a regex object.

Before: 1.49s
After: 1.27s

Benchmark code:
```
import mock
import time
from timeit import timeit
import re
class PatchedDict(dict):
    def __get__(self, *args, **kwargs):
        return None
re._cache = PatchedDict()
from imapclient import IMAPClient

N = 100000

resp = {'OK': ['[PERMANENTFLAGS ()] Flags permitted.', '[UIDVALIDITY 2] UIDs valid.', '[UIDNEXT 102] Predicted next UID.', '[HIGHESTMODSEQ 1097480]'], 'EXISTS': ['0'], 'PERMANENTFLAGS': ['()'], 'HIGHESTMODSEQ': ['1097480'], 'UIDNEXT': ['102'], 'FLAGS': ['(\\Answered \\Flagged \\Draft \\Deleted \\Seen $NotPhishing $Phishing)'], 'UIDVALIDITY': ['2'], 'READ-ONLY': [''], 'RECENT': ['0']}
IMAPClient._create_IMAP4 = mock.Mock()
c = IMAPClient('127.0.0.1')
t = timeit('c._process_select_response(resp)', 'from __main__ import c, resp', number=N)
print(t)
```