### PR TITLE
Fix config file parsing for None attributes

### DIFF
--- a/imapclient/config.py
+++ b/imapclient/config.py
@@ -66,6 +66,8 @@ def get_string_config_defaults():
             v = 'true'
         elif v is False:
             v = 'false'
+        elif not v:
+            v = ''
         out[k] = v
     return out
 

--- a/livetest-sample.ini
+++ b/livetest-sample.ini
@@ -4,7 +4,7 @@
 # run "live" tests. These files are also supported by IMAPClient's
 # interactive shell.
 
-[main]
+[DEFAULT]
 host = <host>
 username = <user>
 password = <password>


### PR DESCRIPTION
Previously it was failing with the following exception when a default attribute
was set to None.

```console
$ python3 livetest.py livetest-sample.ini
livetest.py:11: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
Traceback (most recent call last):
  File "livetest.py", line 1096, in <module>
    main()
  File "livetest.py", line 1069, in main
    host_config = parse_argv()
  File "livetest.py", line 1055, in parse_argv
    host_config = parse_config_file(ini_path)
  File "/home/user/dev/imapclient/imapclient/config.py", line 47, in parse_config_file
    parser = SafeConfigParser(get_string_config_defaults())
  File "/usr/lib/python3.7/configparser.py", line 1225, in __init__
    super().__init__(*args, **kwargs)
  File "/usr/lib/python3.7/configparser.py", line 638, in __init__
    self._read_defaults(defaults)
  File "/usr/lib/python3.7/configparser.py", line 1216, in _read_defaults
    self.read_dict({self.default_section: defaults})
  File "/usr/lib/python3.7/configparser.py", line 753, in read_dict
    self.set(section, key, value)
  File "/usr/lib/python3.7/configparser.py", line 1197, in set
    self._validate_value_types(option=option, value=value)
  File "/usr/lib/python3.7/configparser.py", line 1182, in _validate_value_types
    raise TypeError("option values must be strings")
TypeError: option values must be strings
```

Closes #392.