### PR TITLE
Fix useless ref cycle in lexer

### DIFF
--- a/imapclient/response_lexer.py
+++ b/imapclient/response_lexer.py
@@ -53,7 +53,7 @@ class Lexer(object):
     """
 
     def __init__(self, text):
-        self.sources = (LiteralHandlingIter(self, chunk) for chunk in text)
+        self.sources = (LiteralHandlingIter(chunk) for chunk in text)
         self.current_source = None
 
     def read_until(self, stream_i, end_char, escape=True):
@@ -134,8 +134,7 @@ class Lexer(object):
 # literal.
 class LiteralHandlingIter:
 
-    def __init__(self, lexer, resp_record):
-        self.lexer = lexer
+    def __init__(self, resp_record):
         if isinstance(resp_record, tuple):
             # A 'record' with a string which includes a literal marker, and
             # the literal itself.


### PR DESCRIPTION
Remove a useless ref cycle in LiteralHandlingIter. This helps the ref count based garbage collection in CPython.