### PR TITLE
Use next instead of six.next

### DIFF
--- a/imapclient/response_lexer.py
+++ b/imapclient/response_lexer.py
@@ -62,7 +62,7 @@ class Lexer(object):
             for nextchar in stream_i:
                 if escape and nextchar == BACKSLASH:
                     escaper = nextchar
-                    nextchar = six.next(stream_i)
+                    nextchar = next(stream_i)
                     if nextchar != escaper and nextchar != end_char:
                         token.append(escaper)  # Don't touch invalid escaping
                 elif nextchar == end_char:
@@ -164,7 +164,7 @@ class PushableIterator(object):
     def __next__(self):
         if self.pushed:
             return self.pushed.pop()
-        return six.next(self.it)
+        return next(self.it)
 
     # For Python 2 compatibility
     next = __next__

--- a/imapclient/response_parser.py
+++ b/imapclient/response_parser.py
@@ -110,13 +110,13 @@ def parse_fetch_response(text, normalise_times=True, uid_is_key=True):
     parsed_response = defaultdict(dict)
     while True:
         try:
-            msg_id = seq = _int_or_error(six.next(response),
+            msg_id = seq = _int_or_error(next(response),
                                          'invalid message ID')
         except StopIteration:
             break
 
         try:
-            msg_response = six.next(response)
+            msg_response = next(response)
         except StopIteration:
             raise ProtocolError('unexpected EOF')
 

--- a/tests/test_imapclient.py
+++ b/tests/test_imapclient.py
@@ -415,7 +415,7 @@ class TestIdleAndNoop(IMAPClientTest):
         counter = itertools.count()
 
         def fake_get_line():
-            count = six.next(counter)
+            count = next(counter)
             if count == 0:
                 return b'* 1 EXISTS'
             elif count == 1:
@@ -452,7 +452,7 @@ class TestIdleAndNoop(IMAPClientTest):
         counter = itertools.count()
 
         def fake_get_line():
-            count = six.next(counter)
+            count = next(counter)
             if count == 0:
                 return b'* 99 EXISTS'
             else:
@@ -476,7 +476,7 @@ class TestIdleAndNoop(IMAPClientTest):
         counter = itertools.count()
 
         def fake_get_line():
-            count = six.next(counter)
+            count = next(counter)
             if count == 0:
                 return b'* 1 EXISTS'
             elif count == 1:
@@ -522,7 +522,7 @@ class TestIdleAndNoop(IMAPClientTest):
         counter = itertools.count()
 
         def fake_get_line():
-            count = six.next(counter)
+            count = next(counter)
             if count == 0:
                 return b'* 99 EXISTS'
             else:
@@ -571,7 +571,7 @@ class TestIdleAndNoop(IMAPClientTest):
         counter = itertools.count()
 
         def fake_get_response():
-            count = six.next(counter)
+            count = next(counter)
             if count == 0:
                 return b'* 99 EXISTS'
             client._imap.tagged_commands[sentinel.tag] = ('OK', [b'Idle done'])


### PR DESCRIPTION
`six.next` is only needed on Python 2.5, which imapclient doesn't claim support for, so there is no need to use it.