### PR TITLE
remove imaplib dependency

### DIFF
--- a/imapclient/conn.py
+++ b/imapclient/conn.py
@@ -1,0 +1,213 @@
+"""
+Low Level IMAP Connection
+"""
+
+
+import errno
+import socket
+import subprocess
+import sys
+from io import DEFAULT_BUFFER_SIZE
+from logging import getLogger
+from . import exceptions
+
+try:
+    import ssl
+    HAVE_SSL = True
+except ImportError:
+    HAVE_SSL = False
+
+# Maximal line length when calling readline(). This is to prevent
+# reading arbitrary length lines. RFC 3501 and 2060 (IMAP 4rev1)
+# don't specify a line length. RFC 2683 suggests limiting client
+# command lines to 1000 octets and that servers should be prepared
+# to accept command lines up to 8000 octets, so we used to use 10K here.
+# In the modern world (eg: gmail) the response to, for example, a
+# search command can be quite large, so we now use 1M.
+_MAXLINE = 1000000
+
+IMAP4_PORT = 143
+IMAP4_SSL_PORT = 993
+
+logger = getLogger(__name__)
+
+class IMAP4:
+    def __init__(self, host='', port=IMAP4_PORT):
+        self.open(host, port)
+
+    def _create_socket(self):
+        # Default value of IMAP4.host is '', but socket.getaddrinfo()
+        # (which is used by socket.create_connection()) expects None
+        # as a default value for host.
+        host = None if not self.host else self.host
+        sys.audit("imaplib.open", self, self.host, self.port)
+        return socket.create_connection((host, self.port))
+
+    def open(self, host = '', port = IMAP4_PORT):
+        """Setup connection to remote server on "host:port"
+            (default: localhost:standard IMAP4 port).
+        This connection will be used by the routines:
+            read, readline, send, shutdown.
+        """
+        self.host = host
+        self.port = port
+        self.sock = self._create_socket()
+        self.file = self.sock.makefile('rb')
+
+    def read(self, size):
+        """Read 'size' bytes from remote."""
+        return self.file.read(size)
+
+    def readline(self):
+        """Read line from remote."""
+        line = self.file.readline(_MAXLINE + 1)
+        if len(line) > _MAXLINE:
+            raise exceptions.IMAPClientError("got more than %d bytes" % _MAXLINE)
+        return line
+
+    def get_line(self):
+
+        line = self.readline()
+        if not line:
+            raise exceptions.IMAPClientAbortError('socket error: EOF')
+
+        # Protocol mandates all lines terminated by CRLF
+        if not line.endswith(b'\r\n'):
+            raise exceptions.IMAPClientAbortError('socket error: unterminated line: %r' % line)
+
+        line = line[:-2]
+        if __debug__:
+            logger.debug('< %r' % line)
+        return line
+
+    def send(self, data):
+        """Send data to remote."""
+        sys.audit("imaplib.send", self, data)
+        self.sock.sendall(data)
+
+    def shutdown(self):
+        """Close I/O established in "open"."""
+        self.file.close()
+        try:
+            self.sock.shutdown(socket.SHUT_RDWR)
+        except OSError as exc:
+            # The server might already have closed the connection.
+            # On Windows, this may result in WSAEINVAL (error 10022):
+            # An invalid operation was attempted.
+            if (exc.errno != errno.ENOTCONN
+                    and getattr(exc, 'winerror', 0) != 10022):
+                raise
+        finally:
+            self.sock.close()
+
+    def socket(self):
+        """Return socket instance used to connect to IMAP4 server.
+
+        socket = <instance>.socket()
+        """
+        return self.sock
+
+
+class IMAP4_SSL(IMAP4):
+
+    """IMAP4 client class over SSL connection
+
+    Instantiate with: IMAP4_SSL([host[, port[, keyfile[, certfile[, ssl_context]]]]])
+
+            host - host's name (default: localhost);
+            port - port number (default: standard IMAP4 SSL port);
+            keyfile - PEM formatted file that contains your private key (default: None);
+            certfile - PEM formatted certificate chain file (default: None);
+            ssl_context - a SSLContext object that contains your certificate chain
+                          and private key (default: None)
+            Note: if ssl_context is provided, then parameters keyfile or
+            certfile should not be set otherwise ValueError is raised.
+
+    for more documentation see the docstring of the parent class IMAP4.
+    """
+    def __init__(self, host='', port=IMAP4_SSL_PORT, keyfile=None,
+                 certfile=None, ssl_context=None):
+
+        if not HAVE_SSL:
+            raise ValueError('SSL support missing')
+
+        if ssl_context is not None and keyfile is not None:
+            raise ValueError("ssl_context and keyfile arguments are mutually "
+                             "exclusive")
+        if ssl_context is not None and certfile is not None:
+            raise ValueError("ssl_context and certfile arguments are mutually "
+                             "exclusive")
+        if keyfile is not None or certfile is not None:
+            import warnings
+            warnings.warn("keyfile and certfile are deprecated, use a "
+                          "custom ssl_context instead", DeprecationWarning, 2)
+        self.keyfile = keyfile
+        self.certfile = certfile
+        if ssl_context is None:
+            ssl_context = ssl._create_stdlib_context(certfile=certfile,
+                                                     keyfile=keyfile)
+        self.ssl_context = ssl_context
+        IMAP4.__init__(self, host, port)
+
+    def _create_socket(self):
+        sock = IMAP4._create_socket(self)
+        return self.ssl_context.wrap_socket(sock,
+                                            server_hostname=self.host)
+
+    def open(self, host='', port=IMAP4_SSL_PORT):
+        """Setup connection to remote server on "host:port".
+            (default: localhost:standard IMAP4 SSL port).
+        This connection will be used by the routines:
+            read, readline, send, shutdown.
+        """
+        IMAP4.open(self, host, port)
+
+class IMAP4_stream(IMAP4):
+
+    """IMAP4 client class over a stream
+
+    Instantiate with: IMAP4_stream(command)
+
+            "command" - a string that can be passed to subprocess.Popen()
+
+    for more documentation see the docstring of the parent class IMAP4.
+    """
+    def __init__(self, command):
+        self.command = command
+        IMAP4.__init__(self)
+
+    def open(self, host = None, port = None):
+        """Setup a stream connection.
+        This connection will be used by the routines:
+            read, readline, send, shutdown.
+        """
+        self.host = None        # For compatibility with parent class
+        self.port = None
+        self.sock = None
+        self.file = None
+        self.process = subprocess.Popen(self.command,
+                                        bufsize=DEFAULT_BUFFER_SIZE,
+                                        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                        shell=True, close_fds=True)
+        self.writefile = self.process.stdin
+        self.readfile = self.process.stdout
+
+    def read(self, size):
+        """Read 'size' bytes from remote."""
+        return self.readfile.read(size)
+
+    def readline(self):
+        """Read line from remote."""
+        return self.readfile.readline()
+
+    def send(self, data):
+        """Send data to remote."""
+        self.writefile.write(data)
+        self.writefile.flush()
+
+    def shutdown(self):
+        """Close I/O established in "open"."""
+        self.readfile.close()
+        self.writefile.close()
+        self.process.wait()
+

--- a/imapclient/exceptions.py
+++ b/imapclient/exceptions.py
@@ -1,12 +1,17 @@
-import imaplib
 
 # Base class allowing to catch any IMAPClient related exceptions
-# To ensure backward compatibility, we "rename" the imaplib general
-# exception class, so we can catch its exceptions without having to
-# deal with it in IMAPClient codebase
-IMAPClientError = imaplib.IMAP4.error
-IMAPClientAbortError = imaplib.IMAP4.abort
-IMAPClientReadOnlyError = imaplib.IMAP4.readonly
+class IMAPClientError(RuntimeError):
+    pass
+
+
+class IMAPClientAbortError(IMAPClientError):
+    # Service errors - close and retry
+    pass
+
+
+class IMAPClientReadOnlyError(IMAPClientError):
+    # Mailbox status changed to READ-ONLY
+    pass
 
 
 class CapabilityError(IMAPClientError):

--- a/imapclient/imap4.py
+++ b/imapclient/imap4.py
@@ -2,15 +2,14 @@
 # Released subject to the New BSD License
 # Please see http://en.wikipedia.org/wiki/BSD_licenses
 
-import imaplib
 import socket
+from . import conn
 
-
-class IMAP4WithTimeout(imaplib.IMAP4):
+class IMAP4WithTimeout(conn.IMAP4):
 
     def __init__(self, address, port, timeout):
         self._timeout = timeout
-        imaplib.IMAP4.__init__(self, address, port)
+        conn.IMAP4.__init__(self, address, port)
 
     def _create_socket(self):
         return socket.create_connection((self.host, self.port), self._timeout.connect)

--- a/imapclient/testable_imapclient.py
+++ b/imapclient/testable_imapclient.py
@@ -30,21 +30,25 @@ class TestableIMAPClient(IMAPClient):
     def __init__(self):
         super(TestableIMAPClient, self).__init__('somehost')
 
-    def _create_IMAP4(self):
-        return MockIMAP4()
+    def _new_tag(self):
+        return 'tag'
+
+    def _connect(self):
+        pass
+
+    def _create_conn(self):
+        return MockConn()
 
 
-class MockIMAP4(Mock):
+class MockConn(Mock):
 
     def __init__(self, *args, **kwargs):
         super(Mock, self).__init__(*args, **kwargs)
-        self.use_uid = True
         self.sent = b''  # Accumulates what was given to send()
-        self.tagged_commands = {}
-        self._starttls_done = False
 
     def send(self, data):
+        print(data)
         self.sent += data
 
-    def _new_tag(self):
-        return 'tag'
+    def get_line(self):
+        return b'* OK [CAPABILITY IMAP4rev1 SASL-IR LOGIN-REFERRALS ID ENABLE IDLE LITERAL+ STARTTLS AUTH=PLAIN] Dovecot ready.'

--- a/imapclient/tls.py
+++ b/imapclient/tls.py
@@ -7,7 +7,7 @@ This module contains IMAPClient's functionality related to Transport
 Layer Security (TLS a.k.a. SSL).
 """
 
-import imaplib
+from . import conn
 import socket
 import ssl
 
@@ -32,7 +32,7 @@ def wrap_socket(sock, ssl_context, host):
     return ssl_context.wrap_socket(sock, server_hostname=host)
 
 
-class IMAP4_TLS(imaplib.IMAP4):
+class IMAP4_TLS(conn.IMAP4):
     """IMAP4 client class for TLS/SSL connections.
 
     Adapted from imaplib.IMAP4_SSL.
@@ -41,7 +41,7 @@ class IMAP4_TLS(imaplib.IMAP4):
     def __init__(self, host, port, ssl_context, timeout):
         self.ssl_context = ssl_context
         self._timeout = timeout
-        imaplib.IMAP4.__init__(self, host, port)
+        conn.IMAP4.__init__(self, host, port)
 
     def open(self, host, port):
         self.host = host
@@ -60,4 +60,4 @@ class IMAP4_TLS(imaplib.IMAP4):
         self.sock.sendall(data)
 
     def shutdown(self):
-        imaplib.IMAP4.shutdown(self)
+        conn.IMAP4.shutdown(self)

--- a/imapclient/util.py
+++ b/imapclient/util.py
@@ -4,9 +4,12 @@
 
 from __future__ import unicode_literals
 
+import re
 import six
 import logging
 from six import binary_type, text_type
+from datetime import datetime, timezone, timedelta
+import binascii, time, calendar
 
 from . import exceptions
 
@@ -43,3 +46,147 @@ def assert_imap_protocol(condition, message=None):
 def chunk(lst, size):
     for i in six.moves.range(0, len(lst), size):
         yield lst[i:i + size]
+
+def redact_password(msg):
+    """Preventing IMAP secrets from going to the logging facility."""
+    for command in ("LOGIN", "AUTHENTICATE"):
+        if command in msg:
+            msg_start = msg.split(command)[0]
+            return "{}{} **REDACTED**".format(msg_start, command)
+    return msg
+
+class _Authenticator:
+
+    """Private class to provide en/decoding
+            for base64-based authentication conversation.
+    """
+
+    def __init__(self, mechinst):
+        self.mech = mechinst    # Callable object to provide/process data
+
+    def process(self, data):
+        ret = self.mech(self.decode(data))
+        if ret is None:
+            return b'*'     # Abort conversation
+        return self.encode(ret)
+
+    def encode(self, inp):
+        #
+        #  Invoke binascii.b2a_base64 iteratively with
+        #  short even length buffers, strip the trailing
+        #  line feed from the result and append.  "Even"
+        #  means a number that factors to both 6 and 8,
+        #  so when it gets to the end of the 8-bit input
+        #  there's no partial 6-bit output.
+        #
+        oup = b''
+        if isinstance(inp, str):
+            inp = inp.encode('utf-8')
+        while inp:
+            if len(inp) > 48:
+                t = inp[:48]
+                inp = inp[48:]
+            else:
+                t = inp
+                inp = b''
+            e = binascii.b2a_base64(t)
+            if e:
+                oup = oup + e[:-1]
+        return oup
+
+    def decode(self, inp):
+        if not inp:
+            return b''
+        return binascii.a2b_base64(inp)
+
+Months = ' Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ')
+Mon2num = {s.encode():n+1 for n, s in enumerate(Months[1:])}
+InternalDate = re.compile(br'.*INTERNALDATE "'
+                          br'(?P<day>[ 0123][0-9])-(?P<mon>[A-Z][a-z][a-z])-(?P<year>[0-9][0-9][0-9][0-9])'
+                          br' (?P<hour>[0-9][0-9]):(?P<min>[0-9][0-9]):(?P<sec>[0-9][0-9])'
+                          br' (?P<zonen>[-+])(?P<zoneh>[0-9][0-9])(?P<zonem>[0-9][0-9])'
+                          br'"')
+
+def Internaldate2tuple(resp):
+    """Parse an IMAP4 INTERNALDATE string.
+
+    Return corresponding local time.  The return value is a
+    time.struct_time tuple or None if the string has wrong format.
+    """
+
+    mo = InternalDate.match(resp)
+    if not mo:
+        return None
+
+    mon = Mon2num[mo.group('mon')]
+    zonen = mo.group('zonen')
+
+    day = int(mo.group('day'))
+    year = int(mo.group('year'))
+    hour = int(mo.group('hour'))
+    min = int(mo.group('min'))
+    sec = int(mo.group('sec'))
+    zoneh = int(mo.group('zoneh'))
+    zonem = int(mo.group('zonem'))
+
+    # INTERNALDATE timezone must be subtracted to get UT
+
+    zone = (zoneh*60 + zonem)*60
+    if zonen == b'-':
+        zone = -zone
+
+    tt = (year, mon, day, hour, min, sec, -1, -1, -1)
+    utc = calendar.timegm(tt) - zone
+
+    return time.localtime(utc)
+
+def Int2AP(num):
+    """Convert integer to A-P string representation."""
+
+    val = b''; AP = b'ABCDEFGHIJKLMNOP'
+    num = int(abs(num))
+    while num:
+        num, mod = divmod(num, 16)
+        val = AP[mod:mod+1] + val
+    return val
+
+
+def Time2Internaldate(date_time):
+
+    """Convert date_time to IMAP4 INTERNALDATE representation.
+
+    Return string in form: '"DD-Mmm-YYYY HH:MM:SS +HHMM"'.  The
+    date_time argument can be a number (int or float) representing
+    seconds since epoch (as returned by time.time()), a 9-tuple
+    representing local time, an instance of time.struct_time (as
+    returned by time.localtime()), an aware datetime instance or a
+    double-quoted string.  In the last case, it is assumed to already
+    be in the correct format.
+    """
+    if isinstance(date_time, (int, float)):
+        dt = datetime.fromtimestamp(date_time,
+                                    timezone.utc).astimezone()
+    elif isinstance(date_time, tuple):
+        try:
+            gmtoff = date_time.tm_gmtoff
+        except AttributeError:
+            if time.daylight:
+                dst = date_time[8]
+                if dst == -1:
+                    dst = time.localtime(time.mktime(date_time))[8]
+                gmtoff = -(time.timezone, time.altzone)[dst]
+            else:
+                gmtoff = -time.timezone
+        delta = timedelta(seconds=gmtoff)
+        dt = datetime(*date_time[:6], tzinfo=timezone(delta))
+    elif isinstance(date_time, datetime):
+        if date_time.tzinfo is None:
+            raise ValueError("date_time must be aware")
+        dt = date_time
+    elif isinstance(date_time, str) and (date_time[0],date_time[-1]) == ('"','"'):
+        return date_time        # Assume in correct format
+    else:
+        raise ValueError("date_time not of a known type")
+    fmt = '"%d-{}-%Y %H:%M:%S %z"'.format(Months[dt.month])
+    return dt.strftime(fmt)
+

--- a/livetest.sh
+++ b/livetest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+podman run --name=dovecot --rm -d -p 14301:143 dovecot/dovecot
+
+cat >/tmp/livetest.ini <<EOF
+[DEFAULT]
+host = localhost
+username = user
+password = pass
+port = 14301
+ssl = false
+EOF
+
+python livetest.py /tmp/livetest.ini
+
+podman rm -f dovecot

--- a/tests/imapclient_test.py
+++ b/tests/imapclient_test.py
@@ -1,8 +1,25 @@
 from imapclient.testable_imapclient import TestableIMAPClient as IMAPClient
 from .util import unittest
 
+from .util import unittest, patch, sentinel, Mock
 
 class IMAPClientTest(unittest.TestCase):
+    initial_state = 'NONAUTH'
 
     def setUp(self):
         self.client = IMAPClient()
+        self.client.state = self.initial_state
+
+        # mock standard low-level interfaces here
+        self.patch_method('_command')
+        self.patch_method('_get_response')
+        self.patch_method('_simple_command')
+        self.patch_method('_untagged_response')
+        self.patch_method('_command_complete')
+
+    def patch_method(self, name):
+        """Patch a method in IMAPClient"""
+        patcher = patch('imapclient.imapclient.IMAPClient.' + name)
+        patcher.start().__func__ = Mock(__name__=name)
+        self.addCleanup(patcher.stop)
+

--- a/tests/test_enable.py
+++ b/tests/test_enable.py
@@ -17,7 +17,7 @@ class TestEnable(IMAPClientTest):
         super(TestEnable, self).setUp()
         self.command = Mock()
         self.client._raw_command_untagged = self.command
-        self.client._imap.state = 'AUTH'
+        self.client.state = 'AUTH'
         self.client._cached_capabilities = [b'ENABLE']
 
     def test_success(self):
@@ -63,7 +63,7 @@ class TestEnable(IMAPClientTest):
         self.assertEqual(resp, [b'FOO', b'BAR'])
 
     def test_wrong_state(self):
-        self.client._imap.state = 'SELECTED'
+        self.client.state = 'SELECTED'
 
         self.assertRaises(
             IllegalStateError,

--- a/tests/test_folder_status.py
+++ b/tests/test_folder_status.py
@@ -7,18 +7,21 @@ from __future__ import unicode_literals
 from .imapclient_test import IMAPClientTest
 from .util import Mock
 
-
 class TestFolderStatus(IMAPClientTest):
 
+    def setUp(self):
+        IMAPClientTest.setUp(self)
+        self.patch_method('_cmd_status')
+
     def test_basic(self):
-        self.client._imap.status.return_value = (
+        self.client._cmd_status.return_value = (
             'OK',
             [b'foo (MESSAGES 3 RECENT 0 UIDNEXT 4 UIDVALIDITY 1435636895 UNSEEN 0)']
         )
 
         out = self.client.folder_status('foo')
 
-        self.client._imap.status.assert_called_once_with(
+        self.client._cmd_status.assert_called_once_with(
             b'"foo"',
             '(MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)'
         )
@@ -31,14 +34,14 @@ class TestFolderStatus(IMAPClientTest):
         })
 
     def test_literal(self):
-        self.client._imap.status.return_value = (
+        self.client._cmd_status.return_value = (
             'OK',
             [(b'{3}', b'foo'), b' (UIDNEXT 4)']
         )
 
         out = self.client.folder_status('foo', ['UIDNEXT'])
 
-        self.client._imap.status.assert_called_once_with(b'"foo"', '(UIDNEXT)')
+        self.client._cmd_status.assert_called_once_with(b'"foo"', '(UIDNEXT)')
         self.assertDictEqual(out, {b'UIDNEXT': 4})
 
     def test_extra_response(self):
@@ -46,7 +49,7 @@ class TestFolderStatus(IMAPClientTest):
         # like this and be broken into two components in the tuple.
         server_response = [b"My files (UIDNEXT 24369)"]
         mock = Mock(return_value=server_response)
-        self.client._command_and_check = mock
+        self.client._subcommand_and_check = mock
 
         resp = self.client.folder_status('My files', ['UIDNEXT'])
         self.assertEqual(resp, {b'UIDNEXT': 24369})
@@ -55,7 +58,7 @@ class TestFolderStatus(IMAPClientTest):
         # ask for. In all known cases, the desired mailbox is last.
         server_response = [b"sent (UIDNEXT 123)\nINBOX (UIDNEXT 24369)"]
         mock = Mock(return_value=server_response)
-        self.client._command_and_check = mock
+        self.client._subcommand_and_check = mock
 
         resp = self.client.folder_status('INBOX', ['UIDNEXT'])
         self.assertEqual(resp, {b'UIDNEXT': 24369})

--- a/tests/test_imapclient.py
+++ b/tests/test_imapclient.py
@@ -17,53 +17,54 @@ from imapclient.exceptions import (
     CapabilityError, IMAPClientError, ProtocolError
 )
 from imapclient.imapclient import (
-    IMAPlibLoggerAdapter, _parse_quota, Quota, MailboxQuotaRoots,
+    _parse_quota, Quota, MailboxQuotaRoots,
     require_capability, _literal
 )
 from imapclient.fixed_offset import FixedOffset
 from imapclient.testable_imapclient import TestableIMAPClient as IMAPClient
 
 from .imapclient_test import IMAPClientTest
-from .util import patch, sentinel, Mock
+from .util import patch, sentinel, Mock, ANY
 
 
 class TestListFolders(IMAPClientTest):
+    initial_state = 'AUTH'
 
     def test_list_folders(self):
-        self.client._imap._simple_command.return_value = ('OK', [b'something'])
-        self.client._imap._untagged_response.return_value = ('LIST', sentinel.folder_data)
+        self.client._simple_command.return_value = ('OK', [b'something'])
+        self.client._untagged_response.return_value = ('LIST', sentinel.folder_data)
         self.client._proc_folder_list = Mock(return_value=sentinel.folder_list)
 
         folders = self.client.list_folders('foo', 'bar')
 
-        self.client._imap._simple_command.assert_called_once_with(
+        self.client._simple_command.assert_called_once_with(
             'LIST', b'"foo"', b'"bar"')
         self.assertEqual(self.client._proc_folder_list.call_args, ((sentinel.folder_data,), {}))
         self.assertTrue(folders is sentinel.folder_list)
 
     def test_list_sub_folders(self):
-        self.client._imap._simple_command.return_value = ('OK', [b'something'])
-        self.client._imap._untagged_response.return_value = ('LSUB', sentinel.folder_data)
+        self.client._simple_command.return_value = ('OK', [b'something'])
+        self.client._untagged_response.return_value = ('LSUB', sentinel.folder_data)
         self.client._proc_folder_list = Mock(return_value=sentinel.folder_list)
 
         folders = self.client.list_sub_folders('foo', 'bar')
 
-        self.client._imap._simple_command.assert_called_once_with(
+        self.client._simple_command.assert_called_once_with(
             'LSUB', b'"foo"', b'"bar"')
         self.assertEqual(self.client._proc_folder_list.call_args, ((sentinel.folder_data,), {}))
         self.assertTrue(folders is sentinel.folder_list)
 
     def test_list_folders_NO(self):
-        self.client._imap._simple_command.return_value = ('NO', [b'badness'])
+        self.client._simple_command.return_value = ('NO', [b'badness'])
         self.assertRaises(IMAPClientError, self.client.list_folders)
 
     def test_list_sub_folders_NO(self):
-        self.client._imap._simple_command.return_value = ('NO', [b'badness'])
+        self.client._simple_command.return_value = ('NO', [b'badness'])
         self.assertRaises(IMAPClientError, self.client.list_folders)
 
     def test_utf7_decoding(self):
-        self.client._imap._simple_command.return_value = ('OK', [b'something'])
-        self.client._imap._untagged_response.return_value = (
+        self.client._simple_command.return_value = ('OK', [b'something'])
+        self.client._untagged_response.return_value = (
             'LIST', [
                 b'(\\HasNoChildren) "/" "A"',
                 b'(\\HasNoChildren) "/" "Hello&AP8-world"',
@@ -71,14 +72,14 @@ class TestListFolders(IMAPClientTest):
 
         folders = self.client.list_folders('foo', 'bar')
 
-        self.client._imap._simple_command.assert_called_once_with('LIST', b'"foo"', b'"bar"')
+        self.client._simple_command.assert_called_once_with('LIST', b'"foo"', b'"bar"')
         self.assertEqual(folders, [((b'\\HasNoChildren',), b'/', 'A'),
                                    ((b'\\HasNoChildren',), b'/', 'Hello\xffworld')])
 
     def test_folder_encode_off(self):
         self.client.folder_encode = False
-        self.client._imap._simple_command.return_value = ('OK', [b'something'])
-        self.client._imap._untagged_response.return_value = (
+        self.client._simple_command.return_value = ('OK', [b'something'])
+        self.client._untagged_response.return_value = (
             'LIST', [
                 b'(\\HasNoChildren) "/" "A"',
                 b'(\\HasNoChildren) "/" "Hello&AP8-world"',
@@ -86,7 +87,7 @@ class TestListFolders(IMAPClientTest):
 
         folders = self.client.list_folders('foo', 'bar')
 
-        self.client._imap._simple_command.assert_called_once_with('LIST', '"foo"', '"bar"')
+        self.client._simple_command.assert_called_once_with('LIST', '"foo"', '"bar"')
         self.assertEqual(folders, [((b'\\HasNoChildren',), b'/', b'A'),
                                    ((b'\\HasNoChildren',), b'/', b'Hello&AP8-world')])
 
@@ -157,11 +158,12 @@ class TestListFolders(IMAPClientTest):
 
 
 class TestFindSpecialFolder(IMAPClientTest):
+    initial_state = 'AUTH'
 
     def test_find_special_folder_with_special_use(self):
         self.client._cached_capabilities = (b'SPECIAL-USE',)
-        self.client._imap._simple_command.return_value = ('OK', [b'something'])
-        self.client._imap._untagged_response.return_value = (
+        self.client._simple_command.return_value = ('OK', [b'something'])
+        self.client._untagged_response.return_value = (
             'LIST', [
                 b'(\\HasNoChildren) "/" "INBOX"',
                 b'(\\HasNoChildren \\Sent) "/" "Sent"',
@@ -173,8 +175,8 @@ class TestFindSpecialFolder(IMAPClientTest):
 
     def test_find_special_folder_with_special_use_single_flag(self):
         self.client._cached_capabilities = (b'SPECIAL-USE',)
-        self.client._imap._simple_command.return_value = ('OK', [b'something'])
-        self.client._imap._untagged_response.return_value = (
+        self.client._simple_command.return_value = ('OK', [b'something'])
+        self.client._untagged_response.return_value = (
             'LIST', [
                 b'(\\HasNoChildren) "/" "INBOX"',
                 b'(\\Sent) "/" "Sent"',
@@ -186,8 +188,8 @@ class TestFindSpecialFolder(IMAPClientTest):
 
     def test_find_special_folder_without_special_use_nor_namespace(self):
         self.client._cached_capabilities = (b'FOO',)
-        self.client._imap._simple_command.return_value = ('OK', [b'something'])
-        self.client._imap._untagged_response.return_value = (
+        self.client._simple_command.return_value = ('OK', [b'something'])
+        self.client._untagged_response.return_value = (
             'LIST', [
                 b'(\\HasNoChildren) "/" "Sent Items"',
             ])
@@ -198,10 +200,11 @@ class TestFindSpecialFolder(IMAPClientTest):
 
 
 class TestSelectFolder(IMAPClientTest):
+    initial_state = 'AUTH'
 
     def test_normal(self):
-        self.client._command_and_check = Mock()
-        self.client._imap.untagged_responses = {
+        self.client._subcommand_and_check = Mock()
+        self.client._untagged_responses = {
             b'exists': [b'3'],
             b'FLAGS': [br"(\Flagged \Deleted abc [foo]/bar def)"],
             b'HIGHESTMODSEQ': [b'127110'],
@@ -219,7 +222,7 @@ class TestSelectFolder(IMAPClientTest):
 
         result = self.client.select_folder(b'folder_name', sentinel.readonly)
 
-        self.client._command_and_check.assert_called_once_with('select',
+        self.client._subcommand_and_check.assert_called_once_with(ANY,
                                                                b'"folder_name"',
                                                                sentinel.readonly)
         self.maxDiff = 99999
@@ -237,37 +240,42 @@ class TestSelectFolder(IMAPClientTest):
 
     def test_unselect(self):
         self.client._cached_capabilities = [b'UNSELECT']
-        self.client._imap._simple_command.return_value = ('OK', ['Unselect completed.'])
-        #self.client._imap._untagged_response.return_value = (
+        self.client._simple_command.return_value = ('OK', ['Unselect completed.'])
+        #self.client._untagged_response.return_value = (
         #    b'OK', [b'("name" "GImap" "vendor" "Google, Inc.")'])
 
         result = self.client.unselect_folder()
         self.assertEqual(result, 'Unselect completed.')
-        self.client._imap._simple_command.assert_called_with('UNSELECT')
+        self.client._simple_command.assert_called_with('UNSELECT')
 
 
 class TestAppend(IMAPClientTest):
+    initial_state = 'AUTH'
+
+    def setUp(self):
+        IMAPClientTest.setUp(self)
+        self.patch_method('_cmd_append')
 
     def test_without_msg_time(self):
-        self.client._imap.append.return_value = ('OK', [b'Good'])
+        self.client._cmd_append.return_value = ('OK', [b'Good'])
         msg = 'hi'
 
         self.client.append('foobar', msg, ['FLAG', 'WAVE'], None)
 
-        self.client._imap.append.assert_called_with(
+        self.client._cmd_append.assert_called_with(
             b'"foobar"', '(FLAG WAVE)', None, b'hi')
 
     @patch('imapclient.imapclient.datetime_to_INTERNALDATE')
     def test_with_msg_time(self, datetime_to_INTERNALDATE):
         datetime_to_INTERNALDATE.return_value = 'somedate'
-        self.client._imap.append.return_value = ('OK', [b'Good'])
+        self.client._cmd_append.return_value = ('OK', [b'Good'])
         msg = b'bye'
 
         self.client.append('foobar', msg, ['FLAG', 'WAVE'],
                            datetime(2009, 4, 5, 11, 0, 5, 0, FixedOffset(2 * 60)))
 
         self.assertTrue(datetime_to_INTERNALDATE.called)
-        self.client._imap.append.assert_called_with(
+        self.client._cmd_append.assert_called_with(
             b'"foobar"', '(FLAG WAVE)', '"somedate"', msg)
 
     def test_multiappend(self):
@@ -280,28 +288,32 @@ class TestAppend(IMAPClientTest):
         )
 
 class TestAclMethods(IMAPClientTest):
+    initial_state = 'AUTH'
 
     def setUp(self):
         super(TestAclMethods, self).setUp()
         self.client._cached_capabilities = [b'ACL']
 
     def test_getacl(self):
-        self.client._imap.getacl.return_value = ('OK', [b'INBOX Fred rwipslda Sally rwip'])
+        self.patch_method('_cmd_getacl')
+        self.client._cmd_getacl.return_value = ('OK', [b'INBOX Fred rwipslda Sally rwip'])
         acl = self.client.getacl('INBOX')
         self.assertSequenceEqual(acl, [(b'Fred', b'rwipslda'), (b'Sally', b'rwip')])
 
     def test_setacl(self):
-        self.client._imap.setacl.return_value = ('OK', [b"SETACL done"])
+        self.patch_method('_cmd_setacl')
+        self.client._cmd_setacl.return_value = ('OK', [b"SETACL done"])
 
         response = self.client.setacl('folder', sentinel.who, sentinel.what)
 
-        self.client._imap.setacl.assert_called_with(b'"folder"',
+        self.client._cmd_setacl.assert_called_with(b'"folder"',
                                                     sentinel.who,
                                                     sentinel.what)
         self.assertEqual(response, b"SETACL done")
 
 
 class TestQuota(IMAPClientTest):
+    initial_state = 'AUTH'
 
     def setUp(self):
         super(TestQuota, self).setUp()
@@ -334,15 +346,15 @@ class TestQuota(IMAPClientTest):
         )
 
     def test__get_quota(self):
-        self.client._command_and_check = Mock()
-        self.client._command_and_check.return_value = (
+        self.client._subcommand_and_check = Mock()
+        self.client._subcommand_and_check.return_value = (
             [b'"User quota" (MESSAGES 42 1000)']
         )
 
         quotas = self.client._get_quota('foo')
 
-        self.client._command_and_check.assert_called_once_with(
-            'getquota', '"foo"'
+        self.client._subcommand_and_check.assert_called_once_with(
+            ANY, '"foo"'
         )
         self.assertEqual(quotas, [Quota('User quota', 'MESSAGES', 42, 1000)])
 
@@ -368,7 +380,7 @@ class TestQuota(IMAPClientTest):
         self.client._raw_command_untagged.return_value = (
             [b'"INBOX" "User quota"']
         )
-        self.client._imap.untagged_responses = dict()
+        self.client._untagged_responses = dict()
 
         resp = self.client.get_quota_root("INBOX")
 
@@ -383,6 +395,7 @@ class TestQuota(IMAPClientTest):
 
 
 class TestIdleAndNoop(IMAPClientTest):
+    initial_state = 'AUTH'
 
     def setUp(self):
         super(TestIdleAndNoop, self).setUp()
@@ -406,19 +419,19 @@ class TestIdleAndNoop(IMAPClientTest):
         ])
 
     def test_idle(self):
-        self.client._imap._command.return_value = sentinel.tag
-        self.client._imap._get_response.return_value = None
+        self.client._command.return_value = sentinel.tag
+        self.client._get_response.return_value = None
 
         self.client.idle()
 
-        self.client._imap._command.assert_called_with('IDLE')
+        self.client._command.assert_called_with('IDLE')
         self.assertEqual(self.client._idle_tag, sentinel.tag)
 
     @patch('imapclient.imapclient.POLL_SUPPORT', False)
     @patch('imapclient.imapclient.select.select')
     def test_idle_check_blocking(self, mock_select):
         mock_sock = Mock()
-        self.client._imap.sock = self.client._imap.sslobj = mock_sock
+        self.client._conn.sock = mock_sock
         mock_select.return_value = ([True], [], [])
         counter = itertools.count()
 
@@ -430,7 +443,7 @@ class TestIdleAndNoop(IMAPClientTest):
                 return b'* 0 EXPUNGE'
             else:
                 raise socket.timeout
-        self.client._imap._get_line = fake_get_line
+        self.client._get_line = fake_get_line
 
         responses = self.client.idle_check()
 
@@ -442,7 +455,7 @@ class TestIdleAndNoop(IMAPClientTest):
     @patch('imapclient.imapclient.select.select')
     def test_idle_check_timeout(self, mock_select):
         mock_sock = Mock()
-        self.client._imap.sock = self.client._imap.sslobj = mock_sock
+        self.client._conn.sock = mock_sock
         mock_select.return_value = ([], [], [])
 
         responses = self.client.idle_check(timeout=0.5)
@@ -455,7 +468,7 @@ class TestIdleAndNoop(IMAPClientTest):
     @patch('imapclient.imapclient.select.select')
     def test_idle_check_with_data(self, mock_select):
         mock_sock = Mock()
-        self.client._imap.sock = self.client._imap.sslobj = mock_sock
+        self.client._conn.sock = mock_sock
         mock_select.return_value = ([True], [], [])
         counter = itertools.count()
 
@@ -465,7 +478,7 @@ class TestIdleAndNoop(IMAPClientTest):
                 return b'* 99 EXISTS'
             else:
                 raise socket.timeout
-        self.client._imap._get_line = fake_get_line
+        self.client._get_line = fake_get_line
 
         responses = self.client.idle_check()
 
@@ -477,7 +490,7 @@ class TestIdleAndNoop(IMAPClientTest):
     @patch('imapclient.imapclient.select.poll')
     def test_idle_check_blocking(self, mock_poll_module):
         mock_sock = Mock(fileno=Mock(return_value=1))
-        self.client._imap.sock = self.client._imap.sslobj = mock_sock
+        self.client._conn.sock = mock_sock
 
         mock_poller = Mock(poll=Mock(return_value=[(1, POLLIN)]))
         mock_poll_module.return_value = mock_poller
@@ -492,7 +505,7 @@ class TestIdleAndNoop(IMAPClientTest):
             else:
                 raise socket.timeout
 
-        self.client._imap._get_line = fake_get_line
+        self.client._conn.get_line = fake_get_line
 
         responses = self.client.idle_check()
 
@@ -506,7 +519,7 @@ class TestIdleAndNoop(IMAPClientTest):
     @patch('imapclient.imapclient.select.poll')
     def test_idle_check_timeout(self, mock_poll_module):
         mock_sock = Mock(fileno=Mock(return_value=1))
-        self.client._imap.sock = self.client._imap.sslobj = mock_sock
+        self.client._conn.sock = mock_sock
 
         mock_poller = Mock(poll=Mock(return_value=[]))
         mock_poll_module.return_value = mock_poller
@@ -523,7 +536,7 @@ class TestIdleAndNoop(IMAPClientTest):
     @patch('imapclient.imapclient.select.poll')
     def test_idle_check_with_data(self, mock_poll_module):
         mock_sock = Mock(fileno=Mock(return_value=1))
-        self.client._imap.sock = self.client._imap.sslobj = mock_sock
+        self.client._conn.sock = mock_sock
 
         mock_poller = Mock(poll=Mock(return_value=[(1, POLLIN)]))
         mock_poll_module.return_value = mock_poller
@@ -536,7 +549,7 @@ class TestIdleAndNoop(IMAPClientTest):
             else:
                 raise socket.timeout
 
-        self.client._imap._get_line = fake_get_line
+        self.client._conn.get_line = fake_get_line
 
         responses = self.client.idle_check()
 
@@ -550,7 +563,7 @@ class TestIdleAndNoop(IMAPClientTest):
         self.client._idle_tag = sentinel.tag
 
         mockSend = Mock()
-        self.client._imap.send = mockSend
+        self.client._conn.send = mockSend
         mockConsume = Mock(return_value=sentinel.out)
         self.client._consume_until_tagged_response = mockConsume
 
@@ -562,7 +575,7 @@ class TestIdleAndNoop(IMAPClientTest):
 
     def test_noop(self):
         mockCommand = Mock(return_value=sentinel.tag)
-        self.client._imap._command = mockCommand
+        self.client._command = mockCommand
         mockConsume = Mock(return_value=sentinel.out)
         self.client._consume_until_tagged_response = mockConsume
 
@@ -574,7 +587,7 @@ class TestIdleAndNoop(IMAPClientTest):
 
     def test_consume_until_tagged_response(self):
         client = self.client
-        client._imap.tagged_commands = {sentinel.tag: None}
+        client._tagged_commands = {sentinel.tag: None}
 
         counter = itertools.count()
 
@@ -582,69 +595,31 @@ class TestIdleAndNoop(IMAPClientTest):
             count = next(counter)
             if count == 0:
                 return b'* 99 EXISTS'
-            client._imap.tagged_commands[sentinel.tag] = ('OK', [b'Idle done'])
-        client._imap._get_response = fake_get_response
+            client._tagged_commands[sentinel.tag] = ('OK', [b'Idle done'])
+        client._get_response = fake_get_response
 
         text, responses = client._consume_until_tagged_response(sentinel.tag, b'IDLE')
-        self.assertEqual(client._imap.tagged_commands, {})
+        self.assertEqual(client._tagged_commands, {})
         self.assertEqual(text, b'Idle done')
         self.assertListEqual([(99, b'EXISTS')], responses)
 
+from imapclient.util import redact_password
 
 class TestDebugLogging(IMAPClientTest):
-
-    def test_IMAP_is_patched(self):
-        # Remove all logging handlers so that the order of tests does not
-        # prevent basicConfig from being executed
-        for handler in logging.root.handlers[:]:
-            logging.root.removeHandler(handler)
-        log_stream = six.StringIO()
-        logging.basicConfig(stream=log_stream, level=logging.DEBUG)
-
-        self.client._imap._mesg('two')
-        self.assertIn('DEBUG:imapclient.imaplib:two', log_stream.getvalue())
-
     def test_redacted_password(self):
-        logger_mock = Mock()
-        logger_mock.manager.disable = logging.DEBUG
-        logger_mock.getEffectiveLevel.return_value = logging.DEBUG
-
-        adapter = IMAPlibLoggerAdapter(logger_mock, dict())
-        if six.PY3:
-            adapter.info("""> b'ICHH1 LOGIN foo@bar.org "secret"'""")
-            if sys.version_info >= (3, 6, 4):
-                # LoggerAdapter in Python 3.6.4+ calls logger.log()
-                logger_mock.log.assert_called_once_with(
-                    logging.INFO,
-                    "> b'ICHH1 LOGIN **REDACTED**",
-                    extra={}
-                )
-            else:
-                # LoggerAdapter in Python 3.4 to 3.6 calls logger._log()
-                logger_mock._log.assert_called_once_with(
-                    logging.INFO,
-                    "> b'ICHH1 LOGIN **REDACTED**",
-                    (),
-                    extra={}
-                )
-        else:
-            # LoggerAdapter in Python 2.7 calls logger.info()
-            adapter.info('> ICHH1 LOGIN foo@bar.org "secret"')
-            logger_mock.info.assert_called_once_with(
-                "> ICHH1 LOGIN **REDACTED**",
-                extra={}
-            )
+        self.assertEqual("> b'ICHH1 LOGIN **REDACTED**", redact_password("""> b'ICHH1 LOGIN foo@bar.org "secret"'"""))
 
 
 class TestTimeNormalisation(IMAPClientTest):
+    initial_state = 'SELECTED'
 
     def test_default(self):
         self.assertTrue(self.client.normalise_times)
 
     @patch('imapclient.imapclient.parse_fetch_response')
     def test_pass_through(self, parse_fetch_response):
-        self.client._imap._command_complete.return_value = ('OK', sentinel.data)
-        self.client._imap._untagged_response.return_value = ('OK', sentinel.fetch_data)
+        self.client._command_complete.return_value = ('OK', sentinel.data)
+        self.client._untagged_response.return_value = ('OK', sentinel.fetch_data)
         self.client.use_uid = sentinel.use_uid
 
         def check(expected):
@@ -667,7 +642,8 @@ class TestNamespace(IMAPClientTest):
         self.client._cached_capabilities = [b'NAMESPACE']
 
     def set_return(self, value):
-        self.client._imap.namespace.return_value = ('OK', [value])
+        self.patch_method('_cmd_namespace')
+        self.client._cmd_namespace.return_value = ('OK', [value])
 
     def test_simple(self):
         self.set_return(b'(("FOO." "/")) NIL NIL')
@@ -699,52 +675,56 @@ class TestNamespace(IMAPClientTest):
 
 class TestCapabilities(IMAPClientTest):
 
+    def setUp(self):
+        IMAPClientTest.setUp(self)
+        self.patch_method('_cmd_capability')
+
     def test_preauth(self):
-        self.client._imap.capabilities = ('FOO', 'BAR')
-        self.client._imap.untagged_responses = {}
+        self.client._preauth_capabilities = ('FOO', 'BAR')
+        self.client._untagged_responses = {}
 
         self.assertEqual(self.client.capabilities(), (b'FOO', b'BAR'))
 
     def test_server_returned_capability_after_auth(self):
-        self.client._imap.capabilities = (b'FOO',)
-        self.client._imap.untagged_responses = {'CAPABILITY': [b'FOO MORE']}
+        self.client._preauth_capabilities = (b'FOO',)
+        self.client._untagged_responses = {'CAPABILITY': [b'FOO MORE']}
 
         self.assertEqual(self.client._cached_capabilities, None)
         self.assertEqual(self.client.capabilities(), (b'FOO', b'MORE'))
         self.assertEqual(self.client._cached_capabilities, (b'FOO', b'MORE'))
-        self.assertEqual(self.client._imap.untagged_responses, {})
+        self.assertEqual(self.client._untagged_responses, {})
 
     def test_caching(self):
-        self.client._imap.capabilities = ('FOO',)
-        self.client._imap.untagged_responses = {}
+        self.client._preauth_capabilities = ('FOO',)
+        self.client._untagged_responses = {}
         self.client._cached_capabilities = (b'FOO', b'MORE')
 
         self.assertEqual(self.client.capabilities(), (b'FOO', b'MORE'))
 
     def test_post_auth_request(self):
-        self.client._imap.capabilities = ('FOO',)
-        self.client._imap.untagged_responses = {}
-        self.client._imap.state = 'SELECTED'
-        self.client._imap.capability.return_value = ('OK', [b'FOO BAR'])
+        self.client._preauth_capabilities = ('FOO',)
+        self.client._untagged_responses = {}
+        self.client.state = 'SELECTED'
+        self.client._cmd_capability.return_value = ('OK', [b'FOO BAR'])
 
         self.assertEqual(self.client.capabilities(), (b'FOO', b'BAR'))
         self.assertEqual(self.client._cached_capabilities, (b'FOO', b'BAR'))
 
     def test_with_starttls(self):
         # Initial connection
-        self.client._imap.capabilities = ('FOO',)
-        self.client._imap.untagged_responses = {}
-        self.client._imap.state = 'NONAUTH'
+        self.client._preauth_capabilities = ('FOO',)
+        self.client._untagged_responses = {}
+        self.client.state = 'NONAUTH'
         self.assertEqual(self.client.capabilities(), (b'FOO',))
 
         # Now do STARTTLS; capabilities change and should be reported.
         self.client._starttls_done = True
-        self.client._imap.capability.return_value = ('OK', [b'FOO BAR'])
+        self.client._cmd_capability.return_value = ('OK', [b'FOO BAR'])
         self.assertEqual(self.client.capabilities(), (b'FOO', b'BAR'))
 
         # Login done; capabilities change again.
-        self.client._imap.state = 'AUTH'
-        self.client._imap.capability.return_value = ('OK', [b'FOO BAR QUX'])
+        self.client.state = 'AUTH'
+        self.client._cmd_capability.return_value = ('OK', [b'FOO BAR QUX'])
         self.assertEqual(self.client.capabilities(), (b'FOO', b'BAR', b'QUX'))
 
     def test_has_capability(self):
@@ -787,12 +767,12 @@ class TestId(IMAPClientTest):
         self.client._cached_capabilities = [b'ID']
 
     def test_id(self):
-        self.client._imap._simple_command.return_value = ('OK', [b'Success'])
-        self.client._imap._untagged_response.return_value = (
+        self.client._simple_command.return_value = ('OK', [b'Success'])
+        self.client._untagged_response.return_value = (
             b'OK', [b'("name" "GImap" "vendor" "Google, Inc.")'])
 
         id_response = self.client.id_({'name': 'IMAPClient'})
-        self.client._imap._simple_command.assert_called_with(
+        self.client._simple_command.assert_called_with(
             'ID', '("name" "IMAPClient")')
 
         self.assertSequenceEqual(
@@ -811,15 +791,15 @@ class TestRawCommand(IMAPClientTest):
 
     def setUp(self):
         super(TestRawCommand, self).setUp()
-        self.client._imap._get_response.return_value = None
-        self.client._imap._command_complete.return_value = ('OK', ['done'])
+        self.client._get_response.return_value = None
+        self.client._command_complete.return_value = ('OK', ['done'])
         self.client._cached_capabilities = ()
 
     def check(self, command, args, expected):
         typ, data = self.client._raw_command(command, args)
         self.assertEqual(typ, 'OK')
         self.assertEqual(data, ['done'])
-        self.assertEqual(self.client._imap.sent, expected)
+        self.assertEqual(self.client._conn.sent, expected)
 
     def test_plain(self):
         self.check(b'search', [b'ALL'],
@@ -857,7 +837,7 @@ class TestRawCommand(IMAPClientTest):
         typ, data = self.client._raw_command(b'APPEND', [b'\xff', _literal(b'hello')], uid=False)
         self.assertEqual(typ, 'OK')
         self.assertEqual(data, ['done'])
-        self.assertEqual(self.client._imap.sent,
+        self.assertEqual(self.client._conn.sent,
                          b'tag APPEND {1+}\r\n'
                          b'\xff  {5+}\r\n'
                          b'hello\r\n')
@@ -874,19 +854,20 @@ class TestRawCommand(IMAPClientTest):
         self.assertRaises(ValueError, self.client._raw_command, u'foo', ['foo'])
 
     def test_failed_continuation_wait(self):
-        self.client._imap._get_response.return_value = b'blah'
-        self.client._imap.tagged_commands['tag'] = ('NO', ['go away'])
+        self.client._get_response.return_value = b'blah'
+        self.client._tagged_commands['tag'] = ('NO', ['go away'])
 
         expected_error = "unexpected response while waiting for continuation response: \(u?'NO', \[u?'go away'\]\)"
         with self.assertRaisesRegex(IMAPClient.AbortError, expected_error):
             self.client._raw_command(b'FOO', [b'\xff'])
 
 class TestExpunge(IMAPClientTest):
+    initial_state = 'SELECTED'
 
     def test_expunge(self):
         mockCommand = Mock(return_value=sentinel.tag)
         mockConsume = Mock(return_value=sentinel.out)
-        self.client._imap._command = mockCommand
+        self.client._command = mockCommand
         self.client._consume_until_tagged_response = mockConsume
         result = self.client.expunge()
         mockCommand.assert_called_with('EXPUNGE')
@@ -894,37 +875,42 @@ class TestExpunge(IMAPClientTest):
         self.assertEqual(sentinel.out, result)
 
     def test_id_expunge(self):
-        self.client._imap.uid.return_value = ('OK', [None])
+        self.client._uid_command_and_check = Mock(return_value = [None])
         self.assertEqual([None], self.client.expunge(['4','5', '6']))
 
 class TestShutdown(IMAPClientTest):
 
     def test_shutdown(self):
         self.client.shutdown()
-        self.client._imap.shutdown.assert_called_once_with()
+        self.client._conn.shutdown.assert_called_once_with()
 
 
 class TestContextManager(IMAPClientTest):
+
+    def setUp(self):
+        IMAPClientTest.setUp(self)
+        self.client.logout = Mock()
+        self.client.shutdown = Mock()
 
     def test_context_manager(self):
         with self.client as client:
             self.assertIsInstance(client, IMAPClient)
 
-        self.client._imap.logout.assert_called_once_with()
+        self.client.logout.assert_called_once_with()
 
     @patch('imapclient.imapclient.logger')
     def test_context_manager_fail_closing(self, mock_logger):
-        self.client._imap.logout.side_effect = RuntimeError("Error logout")
-        self.client._imap.shutdown.side_effect = RuntimeError("Error shutdown")
+        self.client.logout.side_effect = RuntimeError("Error logout")
+        self.client.shutdown.side_effect = RuntimeError("Error shutdown")
 
         with self.client as client:
             self.assertIsInstance(client, IMAPClient)
 
-        self.client._imap.logout.assert_called_once_with()
-        self.client._imap.shutdown.assert_called_once_with()
+        self.client.logout.assert_called_once_with()
+        self.client.shutdown.assert_called_once_with()
         mock_logger.info.assert_called_once_with(
             'Could not close the connection cleanly: %s',
-            self.client._imap.shutdown.side_effect
+            self.client.shutdown.side_effect
         )
 
     def test_exception_inside_context_manager(self):
@@ -937,8 +923,8 @@ class TestProtocolError(IMAPClientTest):
 
     def test_tagged_response_with_parse_error(self):
         client = self.client
-        client._imap.tagged_commands = {sentinel.tag: None}
-        client._imap._get_response = lambda: b'NOT-A-STAR 99 EXISTS'
+        client._tagged_commands = {sentinel.tag: None}
+        client._get_response = lambda: b'NOT-A-STAR 99 EXISTS'
 
         with self.assertRaises(ProtocolError):
             client._consume_until_tagged_response(sentinel.tag, b'IDLE')

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -11,6 +11,7 @@ from .util import Mock
 
 
 class TestSort(IMAPClientTest):
+    initial_state = 'SELECTED'
 
     def setUp(self):
         super(TestSort, self).setUp()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -13,6 +13,7 @@ from .util import patch, sentinel, Mock
 
 
 class TestFlagsConsts(IMAPClientTest):
+    initial_state = 'SELECTED'
 
     def test_flags_are_bytes(self):
         for flag in DELETED, SEEN, ANSWERED, FLAGGED, DRAFT, RECENT:
@@ -21,10 +22,11 @@ class TestFlagsConsts(IMAPClientTest):
 
 
 class TestFlags(IMAPClientTest):
+    initial_state = 'SELECTED'
 
     def setUp(self):
         super(TestFlags, self).setUp()
-        self.client._command_and_check = Mock()
+        self.client._uid_command_and_check = Mock()
 
     def test_get(self):
         with patch.object(self.client, 'fetch', autospec=True,
@@ -52,7 +54,7 @@ class TestFlags(IMAPClientTest):
         if silent:
             expected_command += b".SILENT"
 
-        cc = self.client._command_and_check
+        cc = self.client._uid_command_and_check
         cc.return_value = [
             b'11 (FLAGS (blah foo) UID 1)',
             b'11 (UID 1 OTHER (dont))',
@@ -61,10 +63,9 @@ class TestFlags(IMAPClientTest):
         ]
         resp = meth([1, 2], 'foo', silent=silent)
         cc.assert_called_once_with(
-            'store', b"1,2",
+            'STORE', b"1,2",
             expected_command,
-            '(foo)',
-            uid=True)
+            '(foo)')
         if silent:
             self.assertIsNone(resp)
         else:
@@ -76,10 +77,11 @@ class TestFlags(IMAPClientTest):
         cc.reset_mock()
 
 class TestGmailLabels(IMAPClientTest):
+    initial_state = 'SELECTED'
 
     def setUp(self):
         super(TestGmailLabels, self).setUp()
-        self.client._command_and_check = Mock()
+        self.client._uid_command_and_check = Mock()
 
     def test_get(self):
         with patch.object(self.client, 'fetch', autospec=True,
@@ -107,7 +109,7 @@ class TestGmailLabels(IMAPClientTest):
         if silent:
             expected_command += b".SILENT"
 
-        cc = self.client._command_and_check
+        cc = self.client._uid_command_and_check
         cc.return_value = [
             b'11 (X-GM-LABELS (&AUE-abel "f\\"o\\"o") UID 1)',
             b'22 (X-GM-LABELS ("f\\"o\\"o") UID 2)',
@@ -116,10 +118,9 @@ class TestGmailLabels(IMAPClientTest):
         ]
         resp = meth([1, 2], 'f"o"o', silent=silent)
         cc.assert_called_once_with(
-            'store', b"1,2",
+            'STORE', b"1,2",
             expected_command,
-            '("f\\"o\\"o")',
-            uid=True)
+            '("f\\"o\\"o")')
         if silent:
             self.assertIsNone(resp)
         else:

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -11,6 +11,7 @@ from .util import Mock
 
 
 class TestThread(IMAPClientTest):
+    initial_state = 'SELECTED'
 
     def setUp(self):
         super(TestThread, self).setUp()

--- a/tests/util.py
+++ b/tests/util.py
@@ -5,9 +5,9 @@
 from __future__ import unicode_literals
 
 try:
-    from unittest.mock import Mock, patch, sentinel, DEFAULT
+    from unittest.mock import Mock, patch, sentinel, DEFAULT, ANY
 except ImportError:
-    from mock import Mock, patch, sentinel, DEFAULT
+    from mock import Mock, patch, sentinel, DEFAULT, ANY
 
 
 def find_unittest2():


### PR DESCRIPTION
I felt like taking a stab at this. It seems to work, though I've only tested against Dovecot. I added a `livetest.sh` file to automate this with podman.

Basically, I incorporated all the calls from imaplib that imapclient was using into IMAPClient or a new conn.IMAP4 class for the low-level stuff. I divided `_command_and_check` into 2 versions:

1. `_uid_command_and_check` -> just calls `_simple_command`, optionally with UID prefix.
2. `_subcommand_and_check` -> wraps an old imaplib method. No UID support.

It should be easy to do a bit more refactoring on a command-by-command basis, merging the old _cmd_XXX() call (that's from imaplib) into the imapclient parent method. Most of the work might actually be updating the unit tests.

There are a few more things to note. It seems like `ACCEPT=UTF8` support was broken, since `imaplib.IMAP4.enable()` wasn't be called - that's where the magic happens. So I just removed that stuff for now. Also, there were a few calls imaplib supported that client doesn't - like get/set annotations. I left those in as private methods.

I'm open to any feedback.