### PR TITLE
Prevent converting numbers with leading zeroes to int. (#390)

### DIFF
--- a/imapclient/response_parser.py
+++ b/imapclient/response_parser.py
@@ -215,7 +215,7 @@ def atom(src, token):
         return literal_text
     elif len(token) >= 2 and (token[:1] == token[-1:] == b'"'):
         return token[1:-1]
-    elif token.isdigit() and token[:1] != b'0':
+    elif token.isdigit() and (token[:1] != b'0' or len(token) == 1):
         # this prevents converting items like 0123 to 123
         return int(token)
     else:

--- a/imapclient/response_parser.py
+++ b/imapclient/response_parser.py
@@ -215,7 +215,8 @@ def atom(src, token):
         return literal_text
     elif len(token) >= 2 and (token[:1] == token[-1:] == b'"'):
         return token[1:-1]
-    elif token.isdigit():
+    elif token.isdigit() and token[:1] != b'0':
+        # this prevents converting items like 0123 to 123
         return int(token)
     else:
         return token

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -41,6 +41,9 @@ class TestParseResponse(unittest.TestCase):
     def test_int(self):
         self._test(b'45', 45)
 
+    def test_int_zero(self):
+        self._test(b'0', 0)
+
     def test_not_an_int(self):
         self._test(b'0123', b'0123')
 

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -41,6 +41,9 @@ class TestParseResponse(unittest.TestCase):
     def test_int(self):
         self._test(b'45', 45)
 
+    def test_not_an_int(self):
+        self._test(b'0123', b'0123')
+
     def test_nil(self):
         self._test(b'NIL', None)
 


### PR DESCRIPTION
This is a minimal attempt to fix bug #390. This fix assumes that when an imap server starts a number with a leading zero, this token should be treated as a string.

As for the suggestion to have a list of attributes that should always be strings:  in our case, we are getting back folder names because we query dovecot for the 'X-MAILBOX' attribute, which is non-standard. I'm not sure if imapclient should maintain/contain a list of (non-standard) attributes that should always be considered a string.

The NIL case might still breaks things, but some manual testing indicates dovecot is smart enough to quote it in that case. I'm not sure if the folder list not being quoted is a dovecot bug or not, but this fix seems easy and makes sense to me.