### PR TITLE
Moved "Logged in/out" traces from INFO to DEBUG level.

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -354,7 +354,7 @@ class IMAPClient(object):
         except exceptions.IMAPClientError as e:
             raise exceptions.LoginError(str(e))
 
-        logger.info('Logged in as %s', username)
+        logger.debug('Logged in as %s', username)
         return rv
 
     def oauth2_login(self, user, access_token, mech='XOAUTH2', vendor=None):
@@ -388,7 +388,7 @@ class IMAPClient(object):
         """
         typ, data = self._imap.logout()
         self._check_resp('BYE', 'logout', typ, data)
-        logger.info('Logged out, connection closed')
+        logger.debug('Logged out, connection closed')
         return data[0]
 
     def shutdown(self):


### PR DESCRIPTION
"Logged in/out" traces on info level can easily result in log pollution,
especially where the library is used within other applications that poll
IMAP servers at regular intervals. In such cases the logs will easily
end up containing hundreds/thousands of lines such as:

```
2020-08-31 15:20:09,715| INFO|imapclient.imapclient|Logged in as me@myemail.com
2020-08-31 15:20:09,910| INFO|imapclient.imapclient|Logged out, connection closed
...
```

Also, this makes the behaviour more consistent with other traces - if all
the "normal flow" connection messages are logged on debug level then so
login/logout traces should be.