### PR TITLE
add optional timeout parameter to IMAP4_TLS.open

### DIFF
--- a/imapclient/tls.py
+++ b/imapclient/tls.py
@@ -43,7 +43,7 @@ class IMAP4_TLS(imaplib.IMAP4):
         self._timeout = timeout
         imaplib.IMAP4.__init__(self, host, port)
 
-    def open(self, host, port):
+    def open(self, host, port, timeout=None):
         self.host = host
         self.port = port
         sock = socket.create_connection((host, port), self._timeout.connect)


### PR DESCRIPTION
This fixes:
```python
  ...
  File "/lib/python3.9/site-packages/imapclient/tls.py", line 44, in __init__
    imaplib.IMAP4.__init__(self, host, port)
  File "/usr/local/lib/python3.9/imaplib.py", line 202, in __init__
    self.open(host, port, timeout)
TypeError: open() takes 3 positional arguments but 4 were given
```

https://github.com/python/cpython/blob/v3.9.0/Lib/imaplib.py#L202