### PR TITLE
Fix IMAP4_TLS for imaplib in Python 3.9+

### DIFF
--- a/imapclient/tls.py
+++ b/imapclient/tls.py
@@ -38,7 +38,7 @@ class IMAP4_TLS(imaplib.IMAP4):
     Adapted from imaplib.IMAP4_SSL.
     """
 
-    def __init__(self, host, port, ssl_context, timeout):
+    def __init__(self, host, port, ssl_context, timeout=None):
         self.ssl_context = ssl_context
         self._timeout = timeout
         imaplib.IMAP4.__init__(self, host, port)
@@ -46,7 +46,9 @@ class IMAP4_TLS(imaplib.IMAP4):
     def open(self, host, port, timeout=None):
         self.host = host
         self.port = port
-        sock = socket.create_connection((host, port), self._timeout.connect)
+        sock = socket.create_connection(
+            (host, port), timeout if timeout is not None else self._timeout
+        )
         self.sock = wrap_socket(sock, self.ssl_context, host)
         self.file = self.sock.makefile('rb')
 


### PR DESCRIPTION
Trying to use [imapautofiler](https://github.com/imapautofiler/imapautofiler) with python 3.9, I get this error:

```
Traceback (most recent call last):
  File "/home/chris/lib/virtualenvs/imapautofiler/bin/imapautofiler", line 10, in <module>
    sys.exit(main())
  File "/home/chris/work/imapautofiler/imapautofiler/imapautofiler/app.py", line 157, in main
    conn = client.open_connection(cfg)
  File "/home/chris/work/imapautofiler/imapautofiler/imapautofiler/client.py", line 34, in open_connection
    return IMAPClient(cfg)
  File "/home/chris/work/imapautofiler/imapautofiler/imapautofiler/client.py", line 131, in __init__
    self._conn = imapclient.IMAPClient(
  File "/home/chris/lib/virtualenvs/imapautofiler/lib/python3.9/site-packages/imapclient/imapclient.py", line 161, in __init__
    self._imap = self._create_IMAP4()
  File "/home/chris/lib/virtualenvs/imapautofiler/lib/python3.9/site-packages/imapclient/imapclient.py", line 172, in _create_IMAP4
    return tls.IMAP4_TLS(self.host, self.port, self.ssl_context,
  File "/home/chris/lib/virtualenvs/imapautofiler/lib/python3.9/site-packages/imapclient/tls.py", line 171, in __init__
    imaplib.IMAP4.__init__(self, host, port)
  File "/usr/lib/python3.9/imaplib.py", line 202, in __init__
    self.open(host, port, timeout)
TypeError: open() takes 3 positional arguments but 4 were given
```

This is due to a [change in imaplib](https://docs.python.org/3/whatsnew/3.9.html#imaplib) in Python 3.9. The `open()` method now accepts a new optional `timeout` argument and this is also passed when `open()` is called inside `imaplib`. `imapclient.IMAP4_TLS` overwrites `open()` but does not accept a `timeout` argument, optional or not, which leads to the above error.

This PR fixes that by adding the `timeout` argument with a default value of `None` to `open()` and also adds a default value of `None` to the `timeout` argument of the `__init__()` method.