### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/imapclient/imap4.py
+++ b/imapclient/imap4.py
@@ -9,15 +9,21 @@ import socket
 class IMAP4WithTimeout(imaplib.IMAP4):
 
     def __init__(self, address, port, timeout):
+        if hasattr(timeout, 'connect'):
+            timeout = timeout.connect
         self._timeout = timeout
         imaplib.IMAP4.__init__(self, address, port)
 
-    def open(self, host='', port=143):
+    def open(self, host='', port=143, timeout=None):
         # This is overridden to make it consistent across Python versions.
+        if timeout is not None:
+            self._timeout = timeout
         self.host = host
         self.port = port
         self.sock = self._create_socket()
         self.file = self.sock.makefile('rb')
 
-    def _create_socket(self):
-        return socket.create_connection((self.host, self.port), self._timeout.connect)
+    def _create_socket(self, timeout=None):
+        if timeout is None:
+            timeout = self._timeout
+        return socket.create_connection((self.host, self.port), timeout)


### PR DESCRIPTION
imaplib in Py3.9 adds optional `timeout` argument to `IMAP4.__init__()` and `IMAP4.open()`.
Avoid crashing when it is really used (imaplib calling open internally, with timeout parameter).
Store just connect timeout to make it consistent with `imaplib.IMAP4`.

This is similar change to 28da86caa22b385b1ae5b050cf9aa829ec2eef71