### PR TITLE
ssl context created with purpose ssl.Purpose.CLIENT_AUTH

### DIFF
--- a/imapclient/tls.py
+++ b/imapclient/tls.py
@@ -27,7 +27,7 @@ def wrap_socket(sock, ssl_context, host):
         return ssl.wrap_socket(sock)
 
     if ssl_context is None:
-        ssl_context = ssl.create_default_context()
+        ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
 
     return ssl_context.wrap_socket(sock, server_hostname=host)
 


### PR DESCRIPTION
in case the ssl_context argument is None the create_default_context method should be created with CLIENT_AUTH 'Purpose' argument because the default is SERVER_AUTH

```
    if ssl_context is None:
        ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
```