### PR TITLE
Fix typo in tox envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,py38,p39
+envlist=py27,py34,py35,py36,py37,py38,py39
 
 # The tests are currently run directly out of the source tree.
 # See the notes in build-sdist for more details.


### PR DESCRIPTION
It made me flinch a little every time I saw the end of `tox` output!

```
  py27: commands succeeded
ERROR:  py34: InterpreterNotFound: python3.4
  py35: commands succeeded
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  p39: commands succeeded
```