### PR TITLE
Run tests with unittest instead of setup.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Install test dependencies
       run: python -m pip install --editable .[test]
     - name: Test
-      run: python setup.py test
+      run: python -m unittest --verbose

--- a/doc/src/contributing.rst
+++ b/doc/src/contributing.rst
@@ -45,7 +45,7 @@ Running Unit Tests
 ------------------
 To run the tests, from the root of the package source run::
 
-     python setup.py test
+    python -m unittest --verbose
 
 Testing Against Multiple Python Versions
 ----------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist=py27,py34,py35,py36,py37,py38,py39
 skipsdist=true
 
 [testenv]
-commands=python setup.py test
+commands=python -m unittest --verbose
 
 [pep8]
 max-line-length=100


### PR DESCRIPTION
Running `setup.py test` is being deprecated. Its warning can be see in [build log](https://github.com/mjs/imapclient/runs/4337372364?check_suite_focus=true#step:6:7):

    WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.

For this project, its purpose is likely to run unittest with automatic test discovery. So I think it can be replaced with `python -m unittest --verbose`.

Using unittest directly is the easiest replacement I can see. Possible alternatives I have considered:

- The warning suggests using tox. I am unsure how to use tox in GitHub Actions properly. GitHub Actions already sets up an isolated environment for building and testing. Running tox inside to create another feels unnecessary. However, using only tox is good for having the test command in one place, instead of the three at the moment: GitHub Actions, tox configuration and described in docs.
- A populator testing package is pytest. It means using the command `python -m pytest` instead. It reads any potential test configurations in one place and it is likely compatible with the current setup. However, this adds an additional test dependency. And the command for executing tests, albeit being quite standard, still needs to be kept track of in different places. Furthermore, pytest is dropping support for both Python 2.7 and 3.4. As far as I can tell, IMAPClient still intends to support Python 3.4.
- Make our own test command to continue using it. Potentially possible. Its maintenance burden likely outweighs any compatibility benefits.