### PR TITLE
Fix render artefacts in changelog

### DIFF
--- a/doc/src/releases.rst
+++ b/doc/src/releases.rst
@@ -356,26 +356,26 @@ greatly speeds up parsing time.
 
 Other
 -----
-  * Perform quoting of Gmail labels. Thanks to Pawel Sz for the fix.
-  * The type of the various flag constants was fixed. Thanks to Thomi
-    Richards for pointing this out.
-  * Now using mock 1.3.0. Thanks to Thomi Richards for the patch.
-  * Fixed handling of very long numeric only folder names. Thanks to
-    Paweł Gorzelany for the patch.
-  * The default charset for gmail_search is now UTF-8. This makes it
-    easier to use any unicode string as a search string and is safe
-    because Gmail supports UTF-8 search criteria.
-  * PEP8 compliance fixed (except for some occasional long lines)
-  * Added a "shutdown" method.
-  * The embedded six package has been removed in favour of using an
-    externally installed instance.
-  * Fixed handling of literals in STATUS responses.
-  * Only use the untagged post-login CAPABILITY response once (if sent
-    by server).
-  * Release history made part of the main documentation.
-  * Clarified how message ids work in the docs.
-  * Livetest infrastructure now works with Yahoo's OAUTH2
-  * Fixed bytes handling in Address.__str__
+- Perform quoting of Gmail labels. Thanks to Pawel Sz for the fix.
+- The type of the various flag constants was fixed. Thanks to Thomi
+  Richards for pointing this out.
+- Now using mock 1.3.0. Thanks to Thomi Richards for the patch.
+- Fixed handling of very long numeric only folder names. Thanks to
+  Paweł Gorzelany for the patch.
+- The default charset for gmail_search is now UTF-8. This makes it
+  easier to use any unicode string as a search string and is safe
+  because Gmail supports UTF-8 search criteria.
+- PEP8 compliance fixed (except for some occasional long lines)
+- Added a "shutdown" method.
+- The embedded six package has been removed in favour of using an
+  externally installed instance.
+- Fixed handling of literals in STATUS responses.
+- Only use the untagged post-login CAPABILITY response once (if sent
+  by server).
+- Release history made part of the main documentation.
+- Clarified how message ids work in the docs.
+- Livetest infrastructure now works with Yahoo's OAUTH2
+- Fixed bytes handling in Address.__str__
 
 ==============
  Version 0.13
@@ -412,10 +412,10 @@ IMAPClient package.
 
 Other
 -----
-  * The docs for various IMAPClient methods, and the HACKING.rst file
-    have been updated.
-  * CONDSTORE live test is now more reliable (especially when running
-    against Gmail)
+- The docs for various IMAPClient methods, and the HACKING.rst file
+  have been updated.
+- CONDSTORE live test is now more reliable (especially when running
+  against Gmail)
 
 ==============
  Version 0.12

--- a/doc/src/releases.rst
+++ b/doc/src/releases.rst
@@ -7,11 +7,13 @@
 Changed
 -------
 - Performance improvements (thanks Carson Ip!)
+
   - 2x faster _maybe_int_to_bytes for Python 2 (#375) 
   - Fix _proc_folder_list quadratic runtime (#374) 
   - Faster utf7 encode (#373). ~40% faster for input with a mix of unicode and
     ASCII chars.
   - Cache regex in _process_select_response
+
 - poll() when available to surpass 1024 file descriptor limit with select() (#377) (thanks Jonny Hatch)
 - Use next instead of six.next as imapclient doesn't claim Python 2.5 support. (#396) (thanks Jasper Spaans)
 - Moved "Logged in/out" traces from INFO to DEBUG level (thanks Fabio Manganiello)


### PR DESCRIPTION
Building documentation was emitting warnings from the release notes page.

```
/home/boni/base/src/imapclient/doc/src/releases.rst:13: WARNING: Unexpected indentation.
/home/boni/base/src/imapclient/doc/src/releases.rst:14: WARNING: Block quote ends without a blank line; unexpected unindent.
```

It seems that sublists must be wrapped by newlines in reStructuredText. Without the newlines, they are treated as text of the preceding bullet point. This can be seen in the hosted documentation: <https://imapclient.readthedocs.io/en/2.2.0/releases.html#changed>. 

The other commit removes leading indentation from two bullet lists. It seems indented lines on their own are automatically blockquotes in reStructuredText.

I took the opportunity to change the lists to use `-` instead of `*`, to fit the text style of the newer changelogs. They happen to be the latest lists to use `*`, so they should fit in fine.