### PR TITLE
Simplify running tests against all Python versions

### DIFF
--- a/doc/src/contributing.rst
+++ b/doc/src/contributing.rst
@@ -49,16 +49,28 @@ To run the tests, from the root of the package source run::
 
 Testing Against Multiple Python Versions
 ----------------------------------------
-When submitting a Pull Request to IMAPClient, tests are automatically ran
+When submitting a Pull Request to IMAPClient, tests are automatically run
 against all the supported Python versions.
 
-It is possible to locally run these tests using `tox`_. Once
+It is possible to run these tests locally using `tox`_. Once
 installed, the ``tox`` command will use the tox.ini file in the root
 of the project source and run the unit tests against the Python
 versions officially supported by IMAPClient (provided these versions
 of Python are installed!).
 
 .. _`tox`: http://testrun.org/tox/
+
+To avoid having to install all Python versions directly on a host, the
+``tox-all`` script can be used. It will run the unit tests inside a Docker
+container which contains all supported Python versions. As long as Docker is
+installed and your user account can sudo to root the following should work::
+
+    ./tox-all
+
+The script passes any arguments on to tox. For example to run just the tests
+just against Python 3.7 do::
+
+    ./tox-all -e py37
 
 Writing Unit Tests
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,7 @@ setup(
     author_email=info["author_email"],
     license="http://en.wikipedia.org/wiki/BSD_licenses",
     url="https://github.com/mjs/imapclient/",
-    download_url="http://menno.io/projects/IMAPClient/IMAPClient-%s.zip"
-    % info["version"],
+    download_url="http://menno.io/projects/IMAPClient/IMAPClient-%s.zip" % info["version"],
     packages=["imapclient"],
     package_data=dict(imapclient=["examples/*.py"]),
     install_requires=main_deps,

--- a/tox-all
+++ b/tox-all
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sudo docker run -v $(pwd):/mnt --rm -it docker.io/fkrull/multi-python:bionic bash -c "cd /mnt; tox $*"

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,21 @@
 [tox]
 envlist=py27,py34,py35,py36,py37,py38,py39
-
-# The tests are currently run directly out of the source tree.
-# See the notes in build-sdist for more details.
-skipsdist=true
+requires=sphinx
 
 [testenv]
-commands=python -m unittest --verbose
+commands=python -m unittest 
+
+[testenv:py27]
+setenv=
+  VIRTUALENV_PIP=19.0.1
+  VIRTUALENV_SETUPTOOLS=43.0.0
+deps=mock
+commands=python -m unittest discover
+
+[testenv:py34]
+setenv=
+  VIRTUALENV_PIP=19.0.1
+  VIRTUALENV_SETUPTOOLS=43.0.0
 
 [pep8]
 max-line-length=100


### PR DESCRIPTION
- Added tox-all script which runs all unit tests against all supported
  Python versions using Docker
- Adjusted tox.ini so that old pip and setuptools versions are used
  where required for old Python versions
- Updated docs to mention tox-all