### PR TITLE
chore: setup `black` for CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+# If a pull-request is pushed then cancel all previously running jobs related
+# to that pull-request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true 
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  PY_COLORS: 1
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v3
+      - run: pip install --upgrade tox
+      - name: Run black code formatter (https://black.readthedocs.io/en/stable/)
+        run: tox -e black -- --check

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -38,8 +38,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"IMAPClient"
-copyright = u"2014, Menno Smits"
+project = "IMAPClient"
+copyright = "2014, Menno Smits"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -179,7 +179,7 @@ htmlhelp_basename = "IMAPClientdoc"
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "IMAPClient.tex", u"IMAPClient Documentation", u"Menno Smits", "manual"),
+    ("index", "IMAPClient.tex", "IMAPClient Documentation", "Menno Smits", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -210,4 +210,4 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "imapclient", u"IMAPClient Documentation", [u"Menno Smits"], 1)]
+man_pages = [("index", "imapclient", "IMAPClient Documentation", ["Menno Smits"], 1)]

--- a/examples/idle_selector_example.py
+++ b/examples/idle_selector_example.py
@@ -13,10 +13,7 @@ with IMAPClient(HOST, timeout=RESPONSE_TIMEOUT_SECONDS) as server:
     server.login(USERNAME, PASSWORD)
     server.select_folder("INBOX", readonly=True)
     server.idle()
-    print(
-        "Connection is now in IDLE mode,"
-        " send yourself an email or quit with ^c"
-    )
+    print("Connection is now in IDLE mode," " send yourself an email or quit with ^c")
     try:
         with DefaultSelector() as selector:
             selector.register(server.socket(), EVENT_READ, None)

--- a/imapclient/config.py
+++ b/imapclient/config.py
@@ -131,7 +131,8 @@ def refresh_oauth2_token(hostname, client_id, client_secret, refresh_token):
         grant_type=b"refresh_token",
     )
     response = urllib.request.urlopen(
-        url, urllib.parse.urlencode(post).encode("ascii")).read()
+        url, urllib.parse.urlencode(post).encode("ascii")
+    ).read()
     return json.loads(response.decode("ascii"))["access_token"]
 
 

--- a/imapclient/exceptions.py
+++ b/imapclient/exceptions.py
@@ -4,6 +4,7 @@ import imaplib
 # To ensure backward compatibility, we "rename" the imaplib general
 # exception class, so we can catch its exceptions without having to
 # deal with it in IMAPClient codebase
+
 IMAPClientError = imaplib.IMAP4.error
 IMAPClientAbortError = imaplib.IMAP4.abort
 IMAPClientReadOnlyError = imaplib.IMAP4.readonly

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -79,21 +79,21 @@ if "MOVE" not in imaplib.Commands:
     imaplib.Commands["MOVE"] = ("AUTH", "SELECTED")
 
 # System flags
-DELETED = br"\Deleted"
-SEEN = br"\Seen"
-ANSWERED = br"\Answered"
-FLAGGED = br"\Flagged"
-DRAFT = br"\Draft"
-RECENT = br"\Recent"  # This flag is read-only
+DELETED = rb"\Deleted"
+SEEN = rb"\Seen"
+ANSWERED = rb"\Answered"
+FLAGGED = rb"\Flagged"
+DRAFT = rb"\Draft"
+RECENT = rb"\Recent"  # This flag is read-only
 
 # Special folders, see RFC6154
 # \Flagged is omitted because it is the same as the flag defined above
-ALL = br"\All"
-ARCHIVE = br"\Archive"
-DRAFTS = br"\Drafts"
-JUNK = br"\Junk"
-SENT = br"\Sent"
-TRASH = br"\Trash"
+ALL = rb"\All"
+ARCHIVE = rb"\Archive"
+DRAFTS = rb"\Drafts"
+JUNK = rb"\Junk"
+SENT = rb"\Sent"
+TRASH = rb"\Trash"
 
 # Personal namespaces that are common among providers
 # used as a fallback when the server does not support the NAMESPACE capability
@@ -108,7 +108,7 @@ _POPULAR_SPECIAL_FOLDERS = {
     JUNK: ("Junk", "Spam"),
 }
 
-_RE_SELECT_RESPONSE = re.compile(br"\[(?P<key>[A-Z-]+)( \((?P<data>.*)\))?\]")
+_RE_SELECT_RESPONSE = re.compile(rb"\[(?P<key>[A-Z-]+)( \((?P<data>.*)\))?\]")
 
 
 class Namespace(tuple):
@@ -1266,9 +1266,7 @@ class IMAPClient(object):
         """
         response = self.fetch(messages, [b"X-GM-LABELS"])
         response = self._filter_fetch_dict(response, b"X-GM-LABELS")
-        return {
-            msg: utf7_decode_sequence(labels) for msg, labels in response.items()
-        }
+        return {msg: utf7_decode_sequence(labels) for msg, labels in response.items()}
 
     def add_gmail_labels(self, messages, labels, silent=False):
         """Add *labels* to *messages* in the currently selected folder.
@@ -1420,6 +1418,7 @@ class IMAPClient(object):
 
         Returns the APPEND response from the server.
         """
+
         def chunks():
             for m in msgs:
                 if isinstance(m, dict):

--- a/livetest.py
+++ b/livetest.py
@@ -303,7 +303,7 @@ class TestGeneral(_TestBase):
     def test_list_folders(self):
         some_folders = ["simple", b"simple2", "L\xffR"]
         if not self.is_fastmail():
-            some_folders.extend([r'test"folder"', br"foo\bar"])
+            some_folders.extend([r'test"folder"', rb"foo\bar"])
         some_folders = self.add_prefix_to_folders(some_folders)
         for name in some_folders:
             self.client.create_folder(name)
@@ -329,7 +329,7 @@ class TestGeneral(_TestBase):
 
         foundInbox = False
         for flags, _, _ in result:
-            if br"\INBOX" in [flag.upper() for flag in flags]:
+            if rb"\INBOX" in [flag.upper() for flag in flags]:
                 foundInbox = True
                 break
         if not foundInbox:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+sphinx
+black==22.3.0

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
     author_email=info["author_email"],
     license="http://en.wikipedia.org/wiki/BSD_licenses",
     url="https://github.com/mjs/imapclient/",
-    download_url="http://menno.io/projects/IMAPClient/IMAPClient-%s.zip" % info["version"],
+    download_url="http://menno.io/projects/IMAPClient/IMAPClient-%s.zip"
+    % info["version"],
     packages=["imapclient"],
     package_data=dict(imapclient=["examples/*.py"]),
     extras_require={"doc": doc_deps},

--- a/tests/test_response_lexer.py
+++ b/tests/test_response_lexer.py
@@ -32,12 +32,12 @@ class TestTokenSource(unittest.TestCase):
         self.check_error([b'"aaa bbb'], message)
 
     def test_escaping(self):
-        self.check([br'"aaa\"bbb"'], [br'"aaa"bbb"'])
-        self.check([br'"aaa\\bbb"'], [br'"aaa\bbb"'])
-        self.check([br'"aaa\\bbb \"\""'], [br'"aaa\bbb """'])
+        self.check([rb'"aaa\"bbb"'], [rb'"aaa"bbb"'])
+        self.check([rb'"aaa\\bbb"'], [rb'"aaa\bbb"'])
+        self.check([rb'"aaa\\bbb \"\""'], [rb'"aaa\bbb """'])
 
     def test_invalid_escape(self):
-        self.check([br'"aaa\Zbbb"'], [br'"aaa\Zbbb"'])
+        self.check([rb'"aaa\Zbbb"'], [rb'"aaa\Zbbb"'])
 
     def test_lists(self):
         self.check([b"()"], [b"(", b")"])
@@ -59,7 +59,7 @@ class TestTokenSource(unittest.TestCase):
         self.check([b"aaa [bbb]"], [b"aaa", b"[bbb]"])
 
     def test_no_escaping_in_square_brackets(self):
-        self.check([br"[aaa\\bbb]"], [br"[aaa\\bbb]"])
+        self.check([rb"[aaa\\bbb]"], [rb"[aaa\\bbb]"])
 
     def test_unmatched_square_brackets(self):
         message = "No closing ']'"

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -30,7 +30,7 @@ class TestParseResponse(unittest.TestCase):
     def test_unquoted(self):
         self._test(b"FOO", b"FOO")
         self._test(b"F.O:-O_0;", b"F.O:-O_0;")
-        self._test(br"\Seen", br"\Seen")
+        self._test(rb"\Seen", rb"\Seen")
 
     def test_string(self):
         self._test(b'"TEST"', b"TEST")
@@ -159,9 +159,9 @@ class TestParseResponse(unittest.TestCase):
         self._test(response, (12, b"foo", literal_text))
 
     def test_quoted_specials(self):
-        self._test(br'"\"foo bar\""', b'"foo bar"')
-        self._test(br'"foo \"bar\""', b'foo "bar"')
-        self._test(br'"foo\\bar"', br"foo\bar")
+        self._test(rb'"\"foo bar\""', b'"foo bar"')
+        self._test(rb'"foo \"bar\""', b'foo "bar"')
+        self._test(rb'"foo\\bar"', rb"foo\bar")
 
     def test_square_brackets(self):
         self._test(b"foo[bar rrr]", b"foo[bar rrr]")
@@ -263,8 +263,8 @@ class TestParseFetchResponse(unittest.TestCase):
 
     def test_FLAGS(self):
         self.assertEqual(
-            parse_fetch_response([br"23 (FLAGS (\Seen Stuff))"]),
-            {23: {b"SEQ": 23, b"FLAGS": (br"\Seen", b"Stuff")}},
+            parse_fetch_response([rb"23 (FLAGS (\Seen Stuff))"]),
+            {23: {b"SEQ": 23, b"FLAGS": (rb"\Seen", b"Stuff")}},
         )
 
     def test_multiple_messages(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,19 @@
 [tox]
-envlist=py34,py35,py36,py37,py38,py39
-requires=sphinx
+skipsdist = True
+minversion = 3.0
+envlist=py34,py35,py36,py37,py38,py39,black
 
 [testenv]
 commands=python -m unittest 
+deps = -r{toxinidir}/requirements-dev.txt
 
 [testenv:py34]
 setenv=
   VIRTUALENV_PIP=19.0.1
   VIRTUALENV_SETUPTOOLS=43.0.0
 
-[pep8]
-max-line-length=100
-ignore=E731
+[testenv:black]
+basepython = python3
+envdir={toxworkdir}/lint
+commands =
+  black {posargs} .


### PR DESCRIPTION
Commit f0723402d00c5612a428d3815e4f1e653eb68ff0 ran `black` on the
code base. But since it wasn't being enforced in the CI, it has
drifted away from `black` standarized formatting.

Did the following:
  * Added a Github CI job to run `black`
  * Added a `black` tox environment
  * Ran `black` on the code
  * Added the `requirements-dev.txt` file


This has been setup so that it should be easy to add other
checkers/linters in the future as desired.