### PR TITLE
chore: remove support for Python 3.4 & 3.5. Support Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.4"
-          - "3.5"
           - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.10"
           - "pypy3"
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ library.
 
 =========================  ========================================
 Current version            2.3.1
-Supported Python versions  3.4 - 3.9
+Supported Python versions  3.6 - 3.10
 License                    New BSD
 Project home               https://github.com/mjs/imapclient/
 PyPI                       https://pypi.python.org/pypi/IMAPClient

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ Features:
     * Convenience methods are provided for commonly used functionality.
     * Exceptions are raised when errors occur.
 
-Python versions 3.4 through 3.9 are officially supported.
+Python versions 3.6 through 3.10 are officially supported.
 
 IMAPClient includes comprehensive units tests and automated
 functional tests that can be run against a live IMAP server.
@@ -51,7 +51,7 @@ setup(
     package_data=dict(imapclient=["examples/*.py"]),
     extras_require={"doc": doc_deps},
     long_description=desc,
-    python_requires=">=3.4.0",
+    python_requires=">=3.6.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = True
 minversion = 3.0
-envlist=py34,py35,py36,py37,py38,py39,black
+envlist=py36,py37,py38,py39,py310,black,flake8
 
 [testenv]
 commands=python -m unittest 


### PR DESCRIPTION
  * Update the code and docs to remove support for Python 3.4 and 3.5.
  * State that Python 3.10 is supported.
  * Add Python 3.10 to the testing in the CI

Closes: #479