### PR TITLE
fix: broken `get()` & `getboolean()`

### DIFF
--- a/imapclient/config.py
+++ b/imapclient/config.py
@@ -71,10 +71,10 @@ def get_string_config_defaults():
 
 
 def _read_config_section(parser, section):
-    def get(section, name):
+    def get(name):
         return parser.get(section, name)
 
-    def getboolean(section, name):
+    def getboolean(name):
         return parser.getboolean(section, name)
 
     def get_allowing_none(name, typefunc):

--- a/livetest.py
+++ b/livetest.py
@@ -14,6 +14,7 @@ import socket
 import string
 import sys
 import time
+import unittest
 from datetime import datetime
 from email.utils import make_msgid
 
@@ -29,7 +30,6 @@ from imapclient.imapclient import (
 )
 from imapclient.response_types import Envelope, Address
 from imapclient.util import to_bytes, to_unicode
-from tests.util import unittest
 
 # TODO cleaner verbose output: avoid "__main__" and separator between classes
 


### PR DESCRIPTION
Commit 92255e96cd555cbf105e6a007c473aeb1ad2d343 introduced a bug by
adding `section` to the argument list, but the callers don't send
`section`.

Fix this by removing `section` from the argument list.

Commit https://github.com/mjs/imapclient/commit/6e6ec34b0e71975134d9492add22361ce4beb2a0 removed the
`tests/utils.py` file but missed updating `livetest.py`

Import `unittest` directly from `livetest.py`

Discovered while working on adding `mypy` testing.