### PR TITLE
New function `uid_expunge`, which requires the capability UIDPLUS.

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1507,15 +1507,14 @@ class IMAPClient(object):
 
     @require_capability("UIDPLUS")
     def uid_expunge(self, messages):
-        """Same functionality as ``expunge``,
-        but *messages* must be specified,
-        and the capability UIDPLUS is tested beforehand.
-        
+        """Same functionality as ``expunge``, but *messages* must be
+        specified, and the capability UIDPLUS is tested beforehand. It should
+        be more fail-proof than ``expunge`` with *messages*, which cannot be
+        updated to prevent breaking compability with existing codebase.
+
         See :rfc:`4315#section-2.1` section 2.1 for more details.
         """
-        return self._command_and_check(
-            "EXPUNGE", join_message_ids(messages), uid=True
-        )
+        return self._command_and_check("EXPUNGE", join_message_ids(messages), uid=True)
 
     @require_capability("ACL")
     def getacl(self, folder):

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1505,6 +1505,18 @@ class IMAPClient(object):
         tag = self._imap._command("EXPUNGE")
         return self._consume_until_tagged_response(tag, "EXPUNGE")
 
+    @require_capability("UIDPLUS")
+    def uid_expunge(self, messages):
+        """Same functionality as ``expunge``,
+        but *messages* must be specified,
+        and the capability UIDPLUS is tested beforehand.
+        
+        See :rfc:`4315#section-2.1` section 2.1 for more details.
+        """
+        return self._command_and_check(
+            "EXPUNGE", join_message_ids(messages), uid=True
+        )
+
     @require_capability("ACL")
     def getacl(self, folder):
         """Returns a list of ``(who, acl)`` tuples describing the

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1467,7 +1467,10 @@ class IMAPClient(object):
         )
 
     def expunge(self, messages=None):
-        """When, no *messages* are specified, remove all messages
+        """Use of the *messages* argument is discouraged.
+        Please see the ``uid_expunge`` method instead.
+
+        When, no *messages* are specified, remove all messages
         from the currently selected folder that have the
         ``\\Deleted`` flag set.
 
@@ -1475,9 +1478,9 @@ class IMAPClient(object):
         followed by a list of expunge responses. For example::
 
             ('Expunge completed.',
-             [(2, 'EXPUNGE'),
-              (1, 'EXPUNGE'),
-              (0, 'RECENT')])
+            [(2, 'EXPUNGE'),
+            (1, 'EXPUNGE'),
+            (0, 'RECENT')])
 
         In this case, the responses indicate that the message with
         sequence numbers 2 and 1 where deleted, leaving no recent
@@ -1507,10 +1510,10 @@ class IMAPClient(object):
 
     @require_capability("UIDPLUS")
     def uid_expunge(self, messages):
-        """Same functionality as ``expunge``, but *messages* must be
-        specified, and the capability UIDPLUS is tested beforehand. It should
-        be more fail-proof than ``expunge`` with *messages*, which cannot be
-        updated to prevent breaking compability with existing codebase.
+        """Expunge deleted messages with the specified message ids from the
+        folder.
+
+        This requires the UIDPLUS capability.
 
         See :rfc:`4315#section-2.1` section 2.1 for more details.
         """

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1478,9 +1478,9 @@ class IMAPClient(object):
         followed by a list of expunge responses. For example::
 
             ('Expunge completed.',
-            [(2, 'EXPUNGE'),
-            (1, 'EXPUNGE'),
-            (0, 'RECENT')])
+             [(2, 'EXPUNGE'),
+              (1, 'EXPUNGE'),
+              (0, 'RECENT')])
 
         In this case, the responses indicate that the message with
         sequence numbers 2 and 1 where deleted, leaving no recent


### PR DESCRIPTION
The function `expunge` can raise an error at the server side, when the function is utilized with *messages*, and the server does not support the capability UIDPLUS.

Closes #496