### PR TITLE
chore: remove support for Python 3.6. Support Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
           - "pypy-3.9"
     steps:
     - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ library.
 
 =========================  ========================================
 Current version            2.3.1
-Supported Python versions  3.6 - 3.10
+Supported Python versions  3.7 - 3.11
 License                    New BSD
 Project home               https://github.com/mjs/imapclient/
 PyPI                       https://pypi.python.org/pypi/IMAPClient

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ Features:
     * Convenience methods are provided for commonly used functionality.
     * Exceptions are raised when errors occur.
 
-Python versions 3.6 through 3.10 are officially supported.
+Python versions 3.7 through 3.11 are officially supported.
 
 IMAPClient includes comprehensive units tests and automated
 functional tests that can be run against a live IMAP server.
@@ -51,7 +51,7 @@ setup(
     package_data=dict(imapclient=["examples/*.py"]),
     extras_require={"doc": doc_deps},
     long_description=desc,
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,11 @@
 [tox]
 skipsdist = True
 minversion = 3.0
-envlist=py36,py37,py38,py39,py310,black,flake8
+envlist=py37,py38,py39,py310,py311,black,flake8
 
 [testenv]
 commands=python -m unittest 
 deps = -r{toxinidir}/requirements-dev.txt
-
-[testenv:py34]
-setenv=
-  VIRTUALENV_PIP=19.0.1
-  VIRTUALENV_SETUPTOOLS=43.0.0
 
 [testenv:black]
 basepython = python3


### PR DESCRIPTION
  * Update the code and docs to remove support for Python 3.6.
  * State that Python 3.11 is supported.
  * Add Python 3.11 to the testing in the CI

Closes: #512