### PR TITLE
chore: remove `envdir` settings from `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,11 @@ deps = -r{toxinidir}/requirements-dev.txt
 
 [testenv:black]
 basepython = python3
-envdir={toxworkdir}/lint
 commands =
   black {posargs} .
 
 [testenv:flake8]
 basepython = python3
-envdir={toxworkdir}/lint
 commands =
   flake8 {posargs} .
 


### PR DESCRIPTION
In previous versions of `tox` it made sense to use `envdir` to have multiple test environments share the same directory when they had the same requirements.

But since `tox>=4` it no longer makes sense to do this as now `tox` will detect a difference and keep recreating the environment and cause it to be slower than having separate environments. What is happening now is if you run `tox -e black,flake8` it will create the environments. Then run `tox -e black,flake8` again it will again recreate the environments. By removing `envdir` it won't recreate the environments on the second and subsequent runs.