### PR TITLE
Initial framework for adding type-hints and added type-hints to `version.py`

### DIFF
--- a/imapclient/version.py
+++ b/imapclient/version.py
@@ -2,10 +2,12 @@
 # Released subject to the New BSD License
 # Please see http://en.wikipedia.org/wiki/BSD_licenses
 
+from typing import Tuple
+
 version_info = (2, 3, 1, "final")
 
 
-def _imapclient_version_string(vinfo):
+def _imapclient_version_string(vinfo: Tuple[int, int, int, str]) -> str:
     major, minor, micro, releaselevel = vinfo
     v = "%d.%d.%d" % (major, minor, micro)
     if releaselevel != "final":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,67 @@
 profile = "black"
 multi_line_output = 3
 order_by_type = false
+
+[tool.mypy]
+files = "."
+exclude = [
+    "doc/.*",
+    "examples/.*",
+    "tests/.*",
+]
+
+show_error_codes = true
+
+# 'strict = true' is equivalent to:
+#   --check-untyped-defs
+#   --disallow-any-generics
+#   --disallow-incomplete-defs
+#   --disallow-subclassing-any
+#   --disallow-untyped-calls
+#   --disallow-untyped-decorators
+#   --disallow-untyped-defs
+#   --extra-checks
+#   --no-implicit-reexport
+#   --strict-equality
+#   --warn-redundant-casts
+#   --warn-return-any
+#   --warn-unused-configs
+#   --warn-unused-ignores
+
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+extra_checks = true
+no_implicit_reexport = true
+strict_equality = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
+
+# Overrides for currently untyped modules
+[[tool.mypy.overrides]]
+module = [
+    "imapclient.config",
+    "imapclient.datetime_util",
+    "imapclient.fixed_offset",
+    "imapclient.imap4",
+    "imapclient.imap_utf7",
+    "imapclient.imapclient",
+    "imapclient.interact",
+    "imapclient.response_lexer",
+    "imapclient.response_parser",
+    "imapclient.response_types",
+    "imapclient.testable_imapclient",
+    "imapclient.tls",
+    "imapclient.util",
+    "imapclient.version",
+    "interact",
+    "livetest",
+    "setup",
+]
+ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ module = [
     "imapclient.testable_imapclient",
     "imapclient.tls",
     "imapclient.util",
-    "imapclient.version",
     "interact",
     "livetest",
     "setup",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ sphinx
 black==22.3.0
 flake8==4.0.1
 isort==5.12.0
+mypy==1.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = True
 minversion = 3.0
-envlist=py37,py38,py39,py310,py311,black,isort,flake8
+envlist=py37,py38,py39,py310,py311,black,isort,flake8,mypy
 
 [testenv]
 commands=python -m unittest 
@@ -21,6 +21,11 @@ commands =
 basepython = python3
 commands =
   isort {posargs} .
+
+[testenv:mypy]
+basepython = python3
+commands =
+  mypy {posargs}
 
 [flake8]
 exclude = .git,.venv,.tox,dist,doc,*egg,build,


### PR DESCRIPTION
This is adding the initial framework for adding type-hints. It adds the running of `mypy` and type-checks nothing in the first commit.

Then adds type-checking of the file `imapclient/version.py` and others can use that as an example of how to add type-hints by updating `pyproject.toml`