### PR TITLE
chore: resolve formatting issues so `black==23.7.0` check passes

### DIFF
--- a/imapclient/response_lexer.py
+++ b/imapclient/response_lexer.py
@@ -146,7 +146,6 @@ class LiteralHandlingIter:
 
 
 class PushableIterator(object):
-
     NO_MORE = object()
 
     def __init__(self, it):

--- a/imapclient/tls.py
+++ b/imapclient/tls.py
@@ -13,7 +13,6 @@ import ssl
 
 
 def wrap_socket(sock, ssl_context, host):
-
     if not hasattr(ssl, "create_default_context"):
         # Python 2.7.0 - 2.7.8 do not have the concept of ssl contexts.
         # Thus we have to use the less flexible and legacy way of wrapping the

--- a/livetest.py
+++ b/livetest.py
@@ -81,7 +81,6 @@ Content-Type: text/plain; charset="UTF-8"
 
 
 class _TestBase(unittest.TestCase):
-
     conf = None
     use_uid = True
 

--- a/tests/test_imap_utf7.py
+++ b/tests/test_imap_utf7.py
@@ -25,13 +25,13 @@ class IMAP4UTF7TestCase(unittest.TestCase):
     ]
 
     def test_encode(self):
-        for (input, output) in self.tests:
+        for input, output in self.tests:
             encoded = encode(input)
             self.assertIsInstance(encoded, bytes)
             self.assertEqual(encoded, output)
 
     def test_decode(self):
-        for (input, output) in self.tests:
+        for input, output in self.tests:
             decoded = decode(output)
             self.assertIsInstance(decoded, str)
             self.assertEqual(input, decoded)


### PR DESCRIPTION
In order to upgrade to `black==23.7.0` some re-formatting is required.

Reformat the code, so that the Dependabot PR will pass CI.