### PR TITLE
chore: add initial `pylint` check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,5 @@ jobs:
         run: tox -e isort -- --check
       - name: Run flake8 (https://flake8.pycqa.org/en/latest/)
         run: tox -e flake8
+      - name: Run pylint Python code static checker (https://github.com/PyCQA/pylint)
+        run: tox -e pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,50 @@ module = [
     "setup",
 ]
 ignore_errors = true
+
+[tool.pylint.messages_control]
+max-line-length = 88
+jobs = 0  # Use auto-detected number of multiple processes to speed up Pylint.
+# TODO(jlvillal): Work on removing these disables over time.
+disable = [
+    "attribute-defined-outside-init",
+    "bad-classmethod-argument",
+    "broad-exception-caught",
+    "consider-using-f-string",
+    "consider-using-in",
+    "consider-using-ternary",
+    "consider-using-with",
+    "deprecated-method",
+    "fixme",
+    "import-error",
+    "import-outside-toplevel",
+    "inconsistent-return-statements",
+    "invalid-name",
+    "line-too-long",
+    "missing-class-docstring",
+    "missing-function-docstring",
+    "missing-module-docstring",
+    "no-else-break",
+    "no-else-continue",
+    "no-else-return",
+    "no-value-for-parameter",
+    "protected-access",
+    "raise-missing-from",
+    "signature-differs",
+    "simplifiable-if-statement",
+    "super-with-arguments",
+    "too-few-public-methods",
+    "too-many-arguments",
+    "too-many-boolean-expressions",
+    "too-many-branches",
+    "too-many-instance-attributes",
+    "too-many-lines",
+    "too-many-public-methods",
+    "try-except-raise",
+    "undefined-loop-variable",
+    "unnecessary-pass",
+    "unused-argument",
+    "use-dict-literal",
+    "use-list-literal",
+    "useless-object-inheritance",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ black==22.3.0
 flake8==4.0.1
 isort==5.12.0
 mypy==1.5.1
+pylint==2.17.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = True
 minversion = 3.0
-envlist=py37,py38,py39,py310,py311,black,isort,flake8,mypy
+envlist=py37,py38,py39,py310,py311,black,isort,flake8,mypy,pylint
 
 [testenv]
 commands=python -m unittest 
@@ -26,6 +26,11 @@ commands =
 basepython = python3
 commands =
   mypy {posargs}
+
+[testenv:pylint]
+basepython = python3
+commands =
+  pylint {posargs} imapclient/
 
 [flake8]
 exclude = .git,.venv,.tox,dist,doc,*egg,build,


### PR DESCRIPTION
Add an initial `pylint` check. All failing checks were disabled in `pyproject.toml` and no code changes were made.

Recommend in the future to iteratively go through and enable check(s) and resolve issues found.

Closes: #232