### PR TITLE
chore: convert `namedtuple` to `dataclass`

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -2,6 +2,7 @@
 # Released subject to the New BSD License
 # Please see http://en.wikipedia.org/wiki/BSD_licenses
 
+import dataclasses
 import functools
 import imaplib
 import itertools
@@ -10,11 +11,10 @@ import select
 import socket
 import sys
 import warnings
-from collections import namedtuple
 from datetime import date, datetime
 from logging import getLogger, LoggerAdapter
 from operator import itemgetter
-from typing import Optional
+from typing import List, Optional
 
 from . import exceptions, imap4, response_lexer, tls
 from .datetime_util import datetime_to_INTERNALDATE, format_criteria_date
@@ -117,7 +117,8 @@ class Namespace(tuple):
     shared = property(itemgetter(2))
 
 
-class SocketTimeout(namedtuple("SocketTimeout", "connect read")):
+@dataclasses.dataclass
+class SocketTimeout:
     """Represents timeout configuration for an IMAP connection.
 
     :ivar connect: maximum time to wait for a connection attempt to remote server
@@ -128,8 +129,12 @@ class SocketTimeout(namedtuple("SocketTimeout", "connect read")):
     read/write operations can take up to 60 seconds once the connection is done.
     """
 
+    connect: float
+    read: float
 
-class MailboxQuotaRoots(namedtuple("MailboxQuotaRoots", "mailbox quota_roots")):
+
+@dataclasses.dataclass
+class MailboxQuotaRoots:
     """Quota roots associated with a mailbox.
 
     Represents the response of a GETQUOTAROOT command.
@@ -138,8 +143,12 @@ class MailboxQuotaRoots(namedtuple("MailboxQuotaRoots", "mailbox quota_roots")):
     :ivar quota_roots: list of quota roots associated with the mailbox
     """
 
+    mailbox: str
+    quota_roots: List[str]
 
-class Quota(namedtuple("Quota", "quota_root resource usage limit")):
+
+@dataclasses.dataclass
+class Quota:
     """Resource quota.
 
     Represents the response of a GETQUOTA command.
@@ -149,6 +158,11 @@ class Quota(namedtuple("Quota", "quota_root resource usage limit")):
     :ivar usage: the current usage of the resource
     :ivar limit: the maximum allowed usage of the resource
     """
+
+    quota_root: str
+    resource: str
+    usage: bytes
+    limit: bytes
 
 
 def require_capability(capability):

--- a/imapclient/response_parser.py
+++ b/imapclient/response_parser.py
@@ -209,6 +209,12 @@ def _convert_ENVELOPE(
             pass
 
     subject = envelope_response[1]
+    in_reply_to = envelope_response[8]
+    message_id = envelope_response[9]
+    if TYPE_CHECKING:
+        assert isinstance(subject, bytes)
+        assert isinstance(in_reply_to, bytes)
+        assert isinstance(message_id, bytes)
 
     # addresses contains a tuple of addresses
     # from, sender, reply_to, to, cc, bcc headers
@@ -222,6 +228,8 @@ def _convert_ENVELOPE(
                 if TYPE_CHECKING:
                     assert isinstance(addr_tuple, tuple)
                 if addr_tuple:
+                    if TYPE_CHECKING:
+                        addr_tuple = cast(Tuple[bytes, bytes, bytes, bytes], addr_tuple)
                     addrs.append(Address(*addr_tuple))
             addresses.append(tuple(addrs))
         else:
@@ -236,8 +244,8 @@ def _convert_ENVELOPE(
         to=addresses[3],
         cc=addresses[4],
         bcc=addresses[5],
-        in_reply_to=envelope_response[8],
-        message_id=envelope_response[9],
+        in_reply_to=in_reply_to,
+        message_id=message_id,
     )
 
 

--- a/imapclient/response_types.py
+++ b/imapclient/response_types.py
@@ -2,7 +2,8 @@
 # Released subject to the New BSD License
 # Please see http://en.wikipedia.org/wiki/BSD_licenses
 
-from collections import namedtuple
+import dataclasses
+import datetime
 from email.utils import formataddr
 from typing import Any, List, Optional, Tuple, TYPE_CHECKING, Union
 
@@ -10,12 +11,8 @@ from .typing_imapclient import _Atom
 from .util import to_unicode
 
 
-class Envelope(
-    namedtuple(
-        "Envelope",
-        "date subject from_ sender reply_to to cc bcc in_reply_to message_id",
-    )
-):
+@dataclasses.dataclass
+class Envelope:
     r"""Represents envelope structures of messages. Returned when parsing
     ENVELOPE responses.
 
@@ -56,9 +53,20 @@ class Envelope(
     See :rfc:`3501#section-7.4.2` and :rfc:`2822` for further details.
 
     """
+    date: Optional[datetime.datetime]
+    subject: bytes
+    from_: Optional[Tuple["Address", ...]]
+    sender: Optional[Tuple["Address", ...]]
+    reply_to: Optional[Tuple["Address", ...]]
+    to: Optional[Tuple["Address", ...]]
+    cc: Optional[Tuple["Address", ...]]
+    bcc: Optional[Tuple["Address", ...]]
+    in_reply_to: bytes
+    message_id: bytes
 
 
-class Address(namedtuple("Address", "name route mailbox host")):
+@dataclasses.dataclass
+class Address:
     """Represents electronic mail addresses. Used to store addresses in
     :py:class:`Envelope`.
 
@@ -80,6 +88,11 @@ class Address(namedtuple("Address", "name route mailbox host")):
     See also :py:class:`Envelope` for information about handling of
     "group syntax".
     """
+
+    name: bytes
+    route: bytes
+    mailbox: bytes
+    host: bytes
 
     def __str__(self) -> str:
         if self.mailbox and self.host:

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -511,7 +511,7 @@ class TestParseFetchResponse(unittest.TestCase):
 
         output = parse_fetch_response([envelope_str], normalise_times=False)
 
-        self.assertSequenceEqual(
+        self.assertEqual(
             output[1][b"ENVELOPE"],
             Envelope(
                 datetime(2013, 3, 24, 22, 6, 10, tzinfo=FixedOffset(120)),
@@ -547,7 +547,7 @@ class TestParseFetchResponse(unittest.TestCase):
 
         output = parse_fetch_response([envelope_str], normalise_times=False)
 
-        self.assertSequenceEqual(
+        self.assertEqual(
             output[1][b"ENVELOPE"],
             Envelope(
                 None,
@@ -574,7 +574,7 @@ class TestParseFetchResponse(unittest.TestCase):
 
         output = parse_fetch_response([envelope_str], normalise_times=False)
 
-        self.assertSequenceEqual(
+        self.assertEqual(
             output[1][b"ENVELOPE"],
             Envelope(
                 None,
@@ -606,7 +606,7 @@ class TestParseFetchResponse(unittest.TestCase):
 
         output = parse_fetch_response([envelope_str], normalise_times=False)
 
-        self.assertSequenceEqual(
+        self.assertEqual(
             output[1][b"ENVELOPE"],
             Envelope(
                 None,


### PR DESCRIPTION
A `dataclass` is nicer than a `namedtuple`. Makes it is easy to add type-hints and also they have the added flexibility to customize things if desired.