### PR TITLE
Add readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: doc/src/conf.py
+  fail_on_warning: true
+
+python:
+   install:
+   - requirements: requirements-dev.txt


### PR DESCRIPTION
This is no longer optional.

This should hopefully fix the readthedocs failures that have started recently.