### PR TITLE
Fix sphinx warnings

### DIFF
--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -125,7 +125,6 @@ Release History
 ---------------
 
 From release 3.0.0 onwards, release notes are maintained `on Github
-<https://github.com/mjs/imapclient/releases>`_. 
+<https://github.com/mjs/imapclient/releases>`_.
 
 Release notes for older versions can be found :doc:`in these docs <releases>`.
-

--- a/doc/src/releases.rst
+++ b/doc/src/releases.rst
@@ -1,5 +1,7 @@
+:orphan:
+
 .. note::
-   From release 3.0.0 onwards, release notes are maintained 
+   From release 3.0.0 onwards, release notes are maintained
    `on Github <https://github.com/mjs/imapclient/releases>`_.
 
 ===============

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==6.2.1
 black==23.10.0
 flake8==6.1.0
 isort==5.12.0


### PR DESCRIPTION
...and depend on older sphinx which still supports setup.py build_sphinx for now.