### PR TITLE
Fix missing test files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst NEWS.rst HACKING.rst COPYING AUTHORS THANKS
 include livetest.py
 include ez_setup.py
 include interact.py
+include tests/*.py
 recursive-include imapclient/examples *
 recursive-include doc *.txt *.rst *.py *.png *.css *.html
 


### PR DESCRIPTION
`tests/__init__.py` and `tests/imapclient_test.py` were missing from the source distribution. setuptools doesn't automatically include them.

Fixes #563 