### PR TITLE
Move man page to section 7

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -210,4 +210,4 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "imapclient", "IMAPClient Documentation", ["Menno Smits"], 1)]
+man_pages = [("index", "imapclient", "IMAPClient Documentation", ["Menno Smits"], 7)]


### PR DESCRIPTION
The Debian lint tool `lintian` noticed that `imapclient` puts its man page to section 1 although this section is intended for
> Executable programs or shell commands

to quote `man man`.

This patch moves the man page to section 7 which seems more suitable.