### PR TITLE
Fix typo in man page: certifcate -> certificate

### DIFF
--- a/doc/src/advanced.rst
+++ b/doc/src/advanced.rst
@@ -135,7 +135,7 @@ port                 int     Server port to connect to. Defaults to 143 unless `
 ssl                  bool    Use SSL/TLS to connect.
 starttls             bool    Use STARTTLS to connect.
 ssl_check_hostname   bool    If true and SSL is in use, check that certificate matches the hostname (defaults to true)
-ssl_verify_cert      bool    If true and SSL is in use, check that the certifcate is valid (defaults to true).
+ssl_verify_cert      bool    If true and SSL is in use, check that the certificate is valid (defaults to true).
 ssl_ca_file          string  If SSL is true, use this to specify certificate authority certs to validate with.
 timeout              int     Time out I/O operations after this many seconds.
 oauth2               bool    If true, use OAUTH2 to authenticate (``username`` and ``password`` are ignored).


### PR DESCRIPTION
Spotted by Debian's lint tool `lintian`.