### PR TITLE
feat: add popular special folder for SENT provided by qq mail

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -99,7 +99,7 @@ _POPULAR_PERSONAL_NAMESPACES = (("", ""), ("INBOX.", "."))
 
 # Names of special folders that are common among providers
 _POPULAR_SPECIAL_FOLDERS = {
-    SENT: ("Sent", "Sent Items", "Sent items"),
+    SENT: ("Sent", "Sent Items", "Sent items", "Sent Messages"),
     DRAFTS: ("Drafts",),
     ARCHIVE: ("Archive",),
     TRASH: ("Trash", "Deleted Items", "Deleted Messages", "Deleted"),


### PR DESCRIPTION
During my debugging of QQ email, I discovered that sent emails were being correctly filed into the Sent Messages directory.