### PR TITLE
Support Python 3.8 - 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
           - "pypy-3.9"
     steps:
     - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ library.
 
 =========================  ========================================
 Current version            3.0.1
-Supported Python versions  3.7 - 3.11
+Supported Python versions  3.8 - 3.13
 License                    New BSD
 Project home               https://github.com/mjs/imapclient/
 PyPI                       https://pypi.python.org/pypi/IMAPClient

--- a/doc/src/contributing.rst
+++ b/doc/src/contributing.rst
@@ -70,9 +70,9 @@ installed and your user account can sudo to root the following should work::
     ./tox-all
 
 The script passes any arguments on to tox. For example to run just the tests
-just against Python 3.7 do::
+just against Python 3.10 do::
 
-    ./tox-all -e py37
+    ./tox-all -e py310
 
 Writing Unit Tests
 ------------------

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -30,7 +30,7 @@ explains IMAP in detail. Other RFCs also apply to various extensions
 to the base protocol. These are referred to in the documentation below
 where relevant.
 
-Python versions 3.7 through 3.11 are officially supported.
+Python versions 3.8 through 3.13 are officially supported.
 
 Getting Started
 ---------------

--- a/imapclient/testable_imapclient.py
+++ b/imapclient/testable_imapclient.py
@@ -2,7 +2,7 @@
 # Released subject to the New BSD License
 # Please see http://en.wikipedia.org/wiki/BSD_licenses
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 from unittest.mock import Mock
 
 from .imapclient import IMAPClient
@@ -31,7 +31,7 @@ class MockIMAP4(Mock):
         self.sent = b""  # Accumulates what was given to send()
         self.tagged_commands: Dict[Any, Any] = {}
         self.untagged_responses: Dict[Any, Any] = {}
-        self.capabilities = []
+        self.capabilities: List[str] = []
         self._starttls_done = False
 
     def send(self, data: bytes) -> None:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ Features:
     * Convenience methods are provided for commonly used functionality.
     * Exceptions are raised when errors occur.
 
-Python versions 3.7 through 3.11 are officially supported.
+Python versions 3.8 through 3.13 are officially supported.
 
 IMAPClient includes comprehensive units tests and automated
 functional tests that can be run against a live IMAP server.
@@ -50,7 +50,7 @@ setup(
     package_data=dict(imapclient=["examples/*.py"]),
     extras_require={"doc": doc_deps},
     long_description=desc,
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = True
 minversion = 3.0
-envlist=py37,py38,py39,py310,py311,black,isort,flake8,mypy,pylint
+envlist=py38,py39,py310,py311,py312,py313,black,isort,flake8,mypy,pylint
 
 [testenv]
 commands=python -m unittest 


### PR DESCRIPTION
Drop support for 3.7, add 3.12 and 3.13.