### PR TITLE
Reset IMAP state to AUTH after unselect_folder() (fixes #639)

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -830,7 +830,11 @@ class IMAPClient:
         """
         logger.debug("< UNSELECT")
         # IMAP4 class has no `unselect` method so we can't use `_command_and_check` there
-        _typ, data = self._imap._simple_command("UNSELECT")
+        typ, data = self._imap._simple_command("UNSELECT")
+        # Mirror imaplib.IMAP4.unselect: return the connection to the
+        # authenticated state so subsequent commands (e.g. ENABLE) are legal.
+        if typ == "OK":
+            self._imap.state = "AUTH"
         return data[0]
 
     def _process_select_response(self, resp):

--- a/tests/test_imapclient.py
+++ b/tests/test_imapclient.py
@@ -337,6 +337,18 @@ class TestSelectFolder(IMAPClientTest):
         self.assertEqual(result, "Unselect completed.")
         self.client._imap._simple_command.assert_called_with("UNSELECT")
 
+    def test_unselect_resets_state_to_auth(self):
+        # A successful UNSELECT should return the connection to the
+        # authenticated state (mirroring imaplib.IMAP4.unselect) so that
+        # subsequent commands such as ENABLE are legal again. See #639.
+        self.client._cached_capabilities = [b"UNSELECT"]
+        self.client._imap.state = "SELECTED"
+        self.client._imap._simple_command.return_value = ("OK", ["Unselect completed."])
+
+        self.client.unselect_folder()
+
+        self.assertEqual(self.client._imap.state, "AUTH")
+
 
 class TestAppend(IMAPClientTest):
     def test_without_msg_time(self):


### PR DESCRIPTION
## Summary

`unselect_folder()` leaves the connection in the `SELECTED` state, so a subsequent `enable()` raises `IllegalStateError` (issue #639):

```python
imap.select_folder("INBOX")
imap.unselect_folder()
imap.enable("UTF8=ACCEPT")   # -> IllegalStateError: ENABLE command illegal in state SELECTED
```

The root cause is that `unselect_folder()` calls `self._imap._simple_command("UNSELECT")` directly and never resets `self._imap.state` back to `"AUTH"`. In contrast, `imaplib.IMAP4.unselect()` sets `self.state = "AUTH"` when the command succeeds, and `close_folder()` (which goes through `imaplib`'s `close`) works correctly for the same reason.

## Fix

After a successful `UNSELECT` (`typ == "OK"`), set `self._imap.state = "AUTH"`, mirroring `imaplib.IMAP4.unselect()`. This returns the connection to the authenticated state so `enable()` and other AUTH-state commands are legal again. The change is localized to `unselect_folder()` in `imapclient/imapclient.py`.

## Tests

Added `test_unselect_resets_state_to_auth` in `tests/test_imapclient.py` (alongside the existing `test_unselect`). It sets the mock state to `"SELECTED"`, calls `unselect_folder()`, and asserts the state is reset to `"AUTH"`. The test fails on the pristine code and passes with the fix. Full suite: 268 tests pass. `black`, `isort`, and `flake8` are clean on the changed files.

Disclosure: prepared with AI assistance; reviewed and verified locally.
