### PR TITLE
fix: handle unsolicited responses in fetch

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -22,7 +22,7 @@ from .datetime_util import datetime_to_INTERNALDATE, format_criteria_date
 from .imap_utf7 import decode as decode_utf7
 from .imap_utf7 import encode as encode_utf7
 from .response_parser import parse_fetch_response, parse_message_list, parse_response
-from .util import assert_imap_protocol, chunk, to_bytes, to_unicode
+from .util import assert_imap_protocol, chunk, to_bytes, to_ints, to_unicode
 
 if hasattr(select, "poll"):
     POLL_SUPPORT = True
@@ -1375,6 +1375,9 @@ class IMAPClient:
                     b'INTERNALDATE': datetime.datetime(2011, 2, 24, 19, 30, 36),
                     b'SEQ': 110}}
 
+        Note that due to IMAP unsolicited FETCH responses the return
+        value may include fields not matching the original data query.
+        It is up to the caller to handle that gracefully.
         """
         if not messages:
             return {}
@@ -1391,7 +1394,13 @@ class IMAPClient:
         typ, data = self._imap._command_complete("FETCH", tag)
         self._checkok("fetch", typ, data)
         typ, data = self._imap._untagged_response(typ, data, "FETCH")
-        return parse_fetch_response(data, self.normalise_times, self.use_uid)
+        response = parse_fetch_response(data, self.normalise_times, self.use_uid)
+        # Drop unsolicited responses for other messages
+        return {
+            message_id: response[message_id]
+            for message_id in to_ints(messages)
+            if message_id in response
+        }
 
     def append(self, folder, msg, flags=(), msg_time=None):
         """Append a message to *folder*.
@@ -1789,7 +1798,14 @@ class IMAPClient:
         )
         if silent:
             return None
-        return self._filter_fetch_dict(parse_fetch_response(data), fetch_key)
+        response = parse_fetch_response(data)
+        # Drop unsolicited responses for other messages
+        without_unsolicited = {
+            message_id: response[message_id]
+            for message_id in to_ints(messages)
+            if message_id in response
+        }
+        return self._filter_fetch_dict(without_unsolicited, fetch_key)
 
     def _filter_fetch_dict(self, fetch_dict, key):
         return dict((msgid, data[key]) for msgid, data in fetch_dict.items())

--- a/imapclient/util.py
+++ b/imapclient/util.py
@@ -3,7 +3,7 @@
 # Please see http://en.wikipedia.org/wiki/BSD_licenses
 
 import logging
-from typing import Iterator, Optional, Tuple, Union
+from typing import Iterator, Optional, Sequence, Tuple, Union
 
 from . import exceptions
 
@@ -22,6 +22,19 @@ def to_unicode(s: Union[bytes, str]) -> str:
             )
             return s.decode("ascii", "ignore")
     return s
+
+
+def to_ints(
+    messages: Union[bytes, str, int, Sequence[Union[bytes, str, int]]],
+) -> Sequence[int]:
+    """Convert a sequence of values (such as messages)
+    or a single integer value into an sequence of ints
+    """
+    if not messages:
+        return []
+    if isinstance(messages, (int, str, bytes)):
+        return [int(messages)]
+    return [int(i) for i in messages]
 
 
 def to_bytes(s: Union[bytes, str], charset: str = "ascii") -> bytes:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -45,18 +45,25 @@ class TestFlags(IMAPClientTest):
     def check(self, meth, expected_command):
         self._check(meth, expected_command)
         self._check(meth, expected_command, silent=True)
+        self._check(meth, expected_command, unsolicited_noise=True)
+        self._check(meth, expected_command, unsolicited_noise=True, silent=True)
 
-    def _check(self, meth, expected_command, silent=False):
+    def _check(self, meth, expected_command, unsolicited_noise=False, silent=False):
         if silent:
             expected_command += b".SILENT"
 
+        noise = [b"46 (UID 148606 FLAGS (\\Seen))"] if unsolicited_noise else []
+
         cc = self.client._command_and_check
-        cc.return_value = [
-            b"11 (FLAGS (blah foo) UID 1)",
-            b"11 (UID 1 OTHER (dont))",
-            b"22 (FLAGS (foo) UID 2)",
-            b"22 (UID 2 OTHER (care))",
-        ]
+        cc.return_value = (
+            [
+                b"11 (FLAGS (blah foo) UID 1)",
+                b"11 (UID 1 OTHER (dont))",
+                b"22 (FLAGS (foo) UID 2)",
+            ]
+            + noise
+            + [b"22 (UID 2 OTHER (care))"]
+        )
         resp = meth([1, 2], "foo", silent=silent)
         cc.assert_called_once_with("store", b"1,2", expected_command, "(foo)", uid=True)
         if silent:
@@ -104,18 +111,25 @@ class TestGmailLabels(IMAPClientTest):
     def check(self, meth, expected_command):
         self._check(meth, expected_command)
         self._check(meth, expected_command, silent=True)
+        self._check(meth, expected_command, unsolicited_noise=True)
+        self._check(meth, expected_command, unsolicited_noise=True, silent=True)
 
-    def _check(self, meth, expected_command, silent=False):
+    def _check(self, meth, expected_command, unsolicited_noise=False, silent=False):
         if silent:
             expected_command += b".SILENT"
 
+        noise = [b"46 (UID 148606 FLAGS (\\Seen))"] if unsolicited_noise else []
+
         cc = self.client._command_and_check
-        cc.return_value = [
-            b'11 (X-GM-LABELS (&AUE-abel "f\\"o\\"o") UID 1)',
-            b'22 (X-GM-LABELS ("f\\"o\\"o") UID 2)',
-            b"11 (UID 1 FLAGS (dont))",
-            b"22 (UID 2 FLAGS (care))",
-        ]
+        cc.return_value = (
+            [
+                b'11 (X-GM-LABELS (&AUE-abel "f\\"o\\"o") UID 1)',
+                b'22 (X-GM-LABELS ("f\\"o\\"o") UID 2)',
+                b"11 (UID 1 FLAGS (dont))",
+            ]
+            + noise
+            + [b"22 (UID 2 FLAGS (care))"]
+        )
         resp = meth([1, 2], 'f"o"o', silent=silent)
         cc.assert_called_once_with(
             "store", b"1,2", expected_command, '("f\\"o\\"o")', uid=True


### PR DESCRIPTION
Filter out unsolicited responses for messages other than the ones being queried.

Unsolicited responses for messages that are being queried are already handled correctly (the test `test_same_message_appearing_multiple_times` tests that they are correctly merged)

This fixes methods like `get_flags` and `get_gmail_labels` that, when `fetch` returned unsolicited data, would crash (when the unsolicited data did not contain the queried fields), or in theory even return incorrect data (when the unsolicited data would contain the queried fields for other messages - though that sounds unlikely in practice).

Fixes #334 and possibly #564