### PR TITLE
docs: update .readthedocs.yaml to install deps via uv

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,12 +7,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_create_environment:
+      - pip install uv
+    post_install:
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --group dev
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: doc/src/conf.py
   fail_on_warning: true
-
-python:
-   install:
-   - requirements: requirements-dev.txt


### PR DESCRIPTION
requirements-dev.txt no longer exists (dev deps are now declared in pyproject.toml's [dependency-groups]). Install uv in the RTD build environment and point it at RTD's own virtualenv via UV_PROJECT_ENVIRONMENT so 'uv sync --group dev' installs Sphinx (and the rest of the dev group) into the environment RTD uses to run sphinx-build.