### PR TITLE
Reject NUL, CR and LF in _raw_command arguments before sending

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1705,11 +1705,25 @@ class IMAPClient:
             prefix.append(b"UID")
         prefix.append(command)
 
-        line = []
-        for item, is_last in _iter_with_last(prefix + args):
+        # Check every argument before anything goes on the wire: a bad
+        # argument found after a literal was sent would leave the server
+        # waiting inside a half-sent command.
+        for item in prefix + args:
             if not isinstance(item, bytes):
                 raise ValueError("command args must be passed as bytes")
+            if b"\x00" in item:
+                raise ValueError("NUL is not allowed in command arguments")
+            if not _is8bit(item) and _CR_OR_LF.search(item):
+                # CR and LF end the command line on the wire, so an argument
+                # carrying them would be run as extra commands. A literal can
+                # hold them, which is what the 8-bit path already sends.
+                raise ValueError(
+                    "CR and LF are not allowed in command arguments; "
+                    "wrap the value in imapclient._literal to send it as a literal"
+                )
 
+        line = []
+        for item, is_last in _iter_with_last(prefix + args):
             if _is8bit(item):
                 # If a line was already started send it
                 if line:
@@ -1972,6 +1986,9 @@ def as_pairs(items):
 def as_triplets(items):
     a = iter(items)
     return zip(a, a, a)
+
+
+_CR_OR_LF = re.compile(rb"[\r\n]")
 
 
 def _is8bit(data):

--- a/tests/test_imapclient.py
+++ b/tests/test_imapclient.py
@@ -749,6 +749,42 @@ class TestIdleAndNoop(IMAPClientTest):
         self.assertListEqual([(99, b"EXISTS")], responses)
 
 
+class TestRawCommandRejectsControlCharacters(IMAPClientTest):
+    def setUp(self):
+        super().setUp()
+        self.client._imap.send = Mock()
+        self.client._cached_capabilities = (b"IMAP4REV1",)
+
+    def test_crlf_in_a_line_argument_is_rejected_before_sending(self):
+        criterion = b'x"\r\nX1 STORE 1:* +FLAGS (\\Deleted)\r\nX2 EXPUNGE'
+
+        with self.assertRaises(ValueError):
+            self.client._raw_command(b"SEARCH", [b"HEADER", b"Message-ID", criterion])
+
+        self.client._imap.send.assert_not_called()
+
+    def test_crlf_via_search_criteria_is_rejected_before_sending(self):
+        with self.assertRaises(ValueError):
+            self.client.search(["HEADER", "Message-ID", 'x"\r\nX1 NOOP'])
+
+        self.client._imap.send.assert_not_called()
+
+    def test_nul_is_rejected_even_inside_a_literal(self):
+        with self.assertRaises(ValueError):
+            self.client._raw_command(b"SEARCH", [b"TEXT", _literal(b"a\x00b")])
+
+        self.client._imap.send.assert_not_called()
+
+    def test_crlf_inside_a_literal_is_allowed(self):
+        self.client._send_literal = Mock()
+
+        self.client._raw_command(
+            b"SEARCH", [b"TEXT", _literal(b"line one\r\nline two")]
+        )
+
+        self.client._send_literal.assert_called_once()
+
+
 class TestDebugLogging(IMAPClientTest):
     def test_IMAP_is_patched(self):
         # Remove all logging handlers so that the order of tests does not


### PR DESCRIPTION
Fixes #657

`_raw_command` now checks every argument before anything is sent: NUL is rejected everywhere, and CR or LF are rejected in any argument that would go on the command line. Values that are sent as literals (8-bit, or wrapped in `_literal`) may still carry CR and LF, since a literal can hold them. The check runs before the first `send` on purpose: a bad argument found after a literal was already sent would leave the server waiting inside a half-sent command. The existing "args must be bytes" check moved into the same pass.

This is the same set of characters CPython rejects in `imaplib._command` (python/cpython#143921); that check does not reach `_raw_command`, which writes to the socket directly.

Tests in `tests/test_imapclient.py`: CRLF in a line argument via `_raw_command` and via `search()` raises `ValueError` with `_imap.send` never called; NUL inside a literal is rejected; CRLF inside a `_literal` still goes out as a literal. The three reject cases fail on master. Full suite 267 OK; black, isort, flake8, pylint and mypy clean.
